### PR TITLE
Hosts the website draft on gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,10 @@
 
 A website for the [Environmental Enforcement Watch](//environmentalenforcementwatch.org) project by [EDGI](//envirodatagov.org)
 
-## Toolset
-* Written in [Gatsby](https://www.gatsbyjs.org/)
-* Not yet hosted
+Currently staged at https://edgi-govdata-archiving.github.io/EEW-Website/
 
-## Local development
-1. Make sure you have [Node](https://nodejs.org/en/download/) installed
-1. In a local clone of this repo, run `npm install` to install dependencies
-1. You will need the Gatsby CLI tool: `npm install -g gatsby-cli`
-1. Run locally with `gatsby develop` (defaults to [http://localhost:8000/](http://localhost:8000/))
-
-[Gatsby quickstart docs](https://www.gatsbyjs.org/docs/quick-start/)
-
-## Where to edit content
+## For site maintainers
+### Where to edit content
 * Content is located in markdown files (`.md`) in the folder `content` > subfolder [name of the page]. *If you are not a coder, this will usually be the place to go to make edits!*
   * Images that go with a particular page should go into the same folder as the `.md` file
 * Other places content might be:
@@ -25,6 +16,23 @@ A website for the [Environmental Enforcement Watch](//environmentalenforcementwa
 * Styling in general is in a `.css` file. The main one is in `src/global.css.js`. But it might also be in the `.js` file in `src`
 * If this is all very obscure and overwhelming for you, that's ok! Just make sure to do your work in a [branch](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-branches) and submit it via a [pull request](https://docs.github.com/en/articles/about-pull-requests) and then we can review it before it goes live.
 
+## For developers
+### Toolset
+* Written in [Gatsby](https://www.gatsbyjs.org/)
+* Not yet hosted
+
+### Deployment
+This site is hosted on Github Pages and deployed using the npm module [gh-pages](https://github.com/tschaub/gh-pages) as recommended by Gatsby [here](https://www.gatsbyjs.com/docs/how-gatsby-works-with-github-pages/#deploying-to-a-github-pages-subdomain-at-githubio).
+
+Ensure you have dev dependencies installed and then run `npm run deploy` from a local clone of the `main` branch to deploy the branch to https://edgi-govdata-archiving.github.io/EEW-Website/
+
+### Local development
+1. Make sure you have [Node](https://nodejs.org/en/download/) installed
+1. In a local clone of this repo, run `npm install` to install dependencies
+1. You will need the Gatsby CLI tool: `npm install -g gatsby-cli`
+1. Run locally with `gatsby develop` (defaults to [http://localhost:8000/](http://localhost:8000/))
+
+[Gatsby quickstart docs](https://www.gatsbyjs.org/docs/quick-start/)
 
 ## License & Copyright
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,7 @@ module.exports = {
   siteMetadata: {
     ...siteConfig,
   },
+  pathPrefix: "/EEW-Website",
   plugins: [
     `gatsby-plugin-react-helmet`,
     `gatsby-plugin-sitemap`,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Fabian Schultz <desk@fabianschultz.com>",
   "scripts": {
     "develop": "gatsby develop",
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "serve": "gatsby serve",
     "ssr": "npm run build && npm run serve",
     "format": "prettier --config ./.prettierrc --write src/**/*.js",
@@ -61,6 +62,7 @@
     "eslint-plugin-react": "^7.12.4",
     "favicons": "^5.3.0",
     "gatsby-plugin-eslint": "^2.0.3",
+    "gh-pages": "^3.1.0",
     "lighthouse": "^4.0.0",
     "mkdirp": "^0.5.1",
     "node-gyp": "^3.8.0",


### PR DESCRIPTION
Technically it's already live at https://edgi-govdata-archiving.github.io/EEW-Website/ but this catches up the deploy scripts and documentation