### PR TITLE
supports specifying district

### DIFF
--- a/content/congress/congress.json
+++ b/content/congress/congress.json
@@ -20,8 +20,8 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
-    "district": "13",
+    "state":"WY",
+    "district": "00",
     "name":"A person",
     "affil":"Republican",
     "reportStatus":"completed",
@@ -29,8 +29,8 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
-    "district": "13",
+    "state":"OR",
+    "district": "02",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -38,8 +38,8 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
-    "district": "13",
+    "state":"IL",
+    "district": "09",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -47,8 +47,8 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
-    "district": "13",
+    "state":"CA",
+    "district": "56",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -176,7 +176,7 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
+    "state":"OK",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -184,7 +184,7 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
+    "state":"OR",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -192,7 +192,7 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
+    "state":"IL",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -200,7 +200,7 @@
   },
   {
     "rank":"Member",
-    "state":"NY",
+    "state":"IN",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",

--- a/content/congress/congress.json
+++ b/content/congress/congress.json
@@ -3,6 +3,7 @@
   {
     "rank":"Chair",
     "state":"CA",
+    "district": "13",
     "name":"John Doe",
     "affil":"Democrat",
     "reportStatus":"completed",
@@ -11,6 +12,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -19,6 +21,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"A person",
     "affil":"Republican",
     "reportStatus":"completed",
@@ -27,6 +30,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -35,6 +39,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -43,6 +48,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -51,6 +57,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -59,6 +66,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -67,6 +75,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -75,6 +84,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -83,6 +93,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -91,6 +102,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",
@@ -99,6 +111,7 @@
   {
     "rank":"Member",
     "state":"NY",
+    "district": "13",
     "name":"Jane Doe",
     "affil":"Democrat",
     "reportStatus":"notCompleted",

--- a/src/components/congress/congress.js
+++ b/src/components/congress/congress.js
@@ -76,7 +76,12 @@ function Congress({chamber}) {
         select(this).classed(styles.repOnHover,true);
 
         //Set the text of the tooltip
-        tooltip.text(d.name + '\n' + 'Committee ' + d.rank + '\n' + d.affil + '\n' + d.state);
+        var tooltipText = d.name + '\nCommittee ' + d.rank + '\n' + d.affil + '\nRepresenting ' + d.state
+        if (d.district) {
+          tooltip.text(tooltipText + ' ' + d.district)
+        } else {
+          tooltip.text(tooltipText);
+        }
         
         //Position tooltips at mouse location
         var x = event.x,

--- a/src/hooks/use-congress-data.js
+++ b/src/hooks/use-congress-data.js
@@ -8,6 +8,7 @@ export const useCongressData = () => {
           houseData {
             rank
             state
+            district
             name
             affil
             reportStatus


### PR DESCRIPTION
Adds "district" as an optional string field in congress.json. Note that for fields where it does not apply, no district field is added (e.g. in the senateData part of congress.json there is simply no "district" field)