### PR TITLE
tooltip vertically fits content

### DIFF
--- a/src/components/congress/congress.module.css
+++ b/src/components/congress/congress.module.css
@@ -68,7 +68,7 @@
 
 .tip {
   width: fit-content;
-  height: 4.5em;
+  height: fit-content;
   padding: 7px;
   border: 2px solid #55c0ad;
   white-space: pre-line;


### PR DESCRIPTION
this hasn't been a big issue but just in case https://github.com/edgi-govdata-archiving/EEW-Website/issues/193 shows up again this should fix it