### PR TITLE
Update and create Github Actions to ftp files to staging and production

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,9 +1,9 @@
-name: Github Pages Deploy
+name: Deploy to Staging
 on:
   push:
     branches:
       - main
-      
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,3 +13,18 @@ jobs:
         with:
           access-token: ${{ secrets.DEPLOYMENT_TOKEN }}
           deploy-branch: gh-pages
+  uploadToStaging:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: Checkout gh-pages
+      uses: actions/checkout@v1
+      with:
+        ref: 'gh-pages'
+    - name: FTP to staging
+      uses: sebastianpopp/git-ftp-action@releases/v3
+      with:
+        url: ${{ secrets.ftpserver }}
+        user: ${{ secrets.stagingftpuser }}
+        password: ${{ secrets.stagingftppassword }}
+        options: --auto-init --force --verbose --insecure --all

--- a/.github/workflows/release-to-production.yml
+++ b/.github/workflows/release-to-production.yml
@@ -1,0 +1,19 @@
+name: Release to Production
+on:
+  release:
+    types: [published]
+
+jobs:
+  uploadFTP:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        ref: 'gh-pages'
+    - name: FTP to production
+      uses: sebastianpopp/git-ftp-action@releases/v3
+      with:
+        url: ${{ secrets.ftpserver }}
+        user: ${{ secrets.productionftpuser }}
+        password: ${{ secrets.productionftppassword }}
+        options: --auto-init --force --verbose --insecure --all


### PR DESCRIPTION
This updates our Github actions to deploy staging and production on our own server according to this plan:
- Upon merge to `main`, staging Github action is triggered which builds the site to the gh-pages branch and ftp deploys it to staging.environmentalenforcementwatch.org
- Upon a tagged release (through the “Releases” section of the repo), production Github action is triggered which ftp deploys the gh-pages branch to environmentalenforcementwatch.org

After we migrate away from Github Pages we will need to delete the CNAME file in the repo and delete DNS records in Namecheap pointing to Github.