### PR TITLE
adds in the Other report cards

### DIFF
--- a/content/congress/congress.json
+++ b/content/congress/congress.json
@@ -683,6 +683,87 @@
     "affil":"Independent",
     "district": "00",
     "reportStatus":"completed",
-    "url":"https://edgi-govdata-archiving.github.io/CD-report/VT_2020"  
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/VT_2020"
+    }], 
+  "otherHouse": [
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"AZ",
+    "district": "03",
+    "name":"Raúl M. Grijalva",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/AZ03_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"NY",
+    "district": "14",
+    "name":"Alexandria Ocasio-Cortez",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/NY14_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"TX",
+    "district": "20",
+    "name":"Joaquin Castro",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/TX20_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"TX",
+    "district": "21",
+    "name":"Chip Roy",
+    "affil":"Republican",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/TX21_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"TX",
+    "district": "34",
+    "name":"Filemon Vela",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/TX34_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"TX",
+    "district": "35",
+    "name":"Lloyd Doggett",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/TX35_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"VA",
+    "district": "04",
+    "name":"A. Donald McEachin",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/VA04_2020"
+  }],
+  "otherSenate": [
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"CA",
+    "name":"Dianne Feinstein, Kamala Harris",
+    "affil":"Democrat",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/CA_2020"
+  },
+  {
+    "rank":"Not a member of an\nEPA oversight committee",
+    "state":"TX",
+    "name":"John Cornyn, Ted Cruz",
+    "affil":"Republican",
+    "reportStatus":"completed",
+    "url":"https://edgi-govdata-archiving.github.io/CD-report/TX_2020"
   }]
 }

--- a/src/components/congress/congress.js
+++ b/src/components/congress/congress.js
@@ -48,7 +48,7 @@ function Congress({ chamber, language }) {
     congressData = allCongressData.otherHouse;
     if (language == 'spanish') {
       committee =
-       'Boletas de Calificaciones Adicionales de la Cámara de Representantes';
+        'Boletas de Calificaciones Adicionales de la Cámara de Representantes';
     } else {
       committee = 'Additional House Reports';
     }

--- a/src/hooks/use-congress-data.js
+++ b/src/hooks/use-congress-data.js
@@ -22,6 +22,23 @@ export const useCongressData = () => {
             reportStatus
             url
           }
+          otherSenate {
+            rank
+            state
+            name
+            affil
+            reportStatus
+            url
+          }
+          otherHouse {
+            rank
+            state
+            district
+            name
+            affil
+            reportStatus
+            url
+          }
         }
       }
     `

--- a/src/pages/reports-es.js
+++ b/src/pages/reports-es.js
@@ -52,6 +52,8 @@ const ReportsES = ({ data }) => (
         <DataViz>
           <Congress chamber={'senate'} language={'spanish'} />
           <Congress chamber={'house'} language={'spanish'} />
+          <Congress chamber={'otherSenate'} language={'spanish'} />
+          <Congress chamber={'otherHouse'} language={'spanish'} />
         </DataViz>
       </HomeWrapper>
       <div

--- a/src/pages/reports.js
+++ b/src/pages/reports.js
@@ -52,6 +52,8 @@ const Reports = ({ data }) => (
         <DataViz>
           <Congress chamber={'senate'} language={'english'} />
           <Congress chamber={'house'} language={'english'} />
+          <Congress chamber={'otherSenate'} language={'english'} />
+          <Congress chamber={'otherHouse'} language={'english'} />
         </DataViz>
       </HomeWrapper>
       <div


### PR DESCRIPTION
When we're ready, this set of changes adds the non-EPA-oversight-committee report cards in both English and Spanish.

![Screen Shot 2021-05-05 at 12 35 37 PM](https://user-images.githubusercontent.com/454690/117198884-68d29000-ad9e-11eb-9733-7b8ff01df231.png)
