### PR TITLE
Update ReportCardExplorer to take a "language" prop - translate strings to Spanish

### DIFF
--- a/src/components/ReportCardExplorer.js
+++ b/src/components/ReportCardExplorer.js
@@ -3,33 +3,43 @@ import { Link } from 'gatsby'
 import { CongressReportCardData } from '../helpers/congress'
 import ReactTooltip from 'react-tooltip';
 
-const ReportCardExplorer = () =>
+let spanishStrings = {
+  'Senate Environment and Public Works Committee' : 'Comité de Obras Públicas y Medio Ambiente del Senado',
+  'House Energy and Commerce Committee' : 'Comité de Energía y Comercio de la Cámara de Representantes',
+  'Chair' : 'Presidente',
+  'Ranking Member' : 'Miembro de Mayor Rango',
+  'Member' : 'Miembro',
+  'Not a member of an EPA oversight committee' : 'No es un miembro de un comitéque supervisa la EPA',
+
+  'Republican' : 'Republicano',
+  'Democrat' : 'Demócrata',
+  'Independent' : 'Independiente',
+  'Representing' : 'Representando',
+}
+
+let translatedString = (string, language) => language === 'spanish' ? spanishStrings[string] : string;
+
+const ReportCardExplorer = ({language}) =>
   <div className='ReportCardExplorer'>
-    <h3>Senate Environment and Public Works Committee</h3>
+    <h3>{translatedString('Senate Environment and Public Works Committee', language)}</h3>
     {
       CongressReportCardData.senateData.map(congressMember => 
         <Link to={congressMember.url} target='_blank'>
-          <div data-tip={`${congressMember.name} <br /> <strong>${congressMember.rank}</strong> <br /> ${congressMember.affil} <br /> Representing ${congressMember.state}-${congressMember.district}`} 
+          <div data-tip={`${congressMember.name} <br /> <strong>${translatedString(congressMember.rank, language)}</strong> <br /> ${translatedString(congressMember.affil, language)} <br /> ${translatedString('Representing', language)} ${congressMember.state}-${congressMember.district}`} 
                className={`ReportCard ${congressMember.affil} tooltip`}>
             {congressMember.state}
           </div>
         </Link>
       )
     }
-    <h3>House Energy and Commerce Committee</h3>
+    <h3>{translatedString('House Energy and Commerce Committee', language)}</h3>
     {
       CongressReportCardData.houseData.map(congressMember => 
         <Link to={congressMember.url} target='_blank'>
-          <div data-tip={`${congressMember.name} <br /> <strong>${congressMember.rank}</strong> <br /> ${congressMember.affil} <br /> Representing ${congressMember.state}-${congressMember.district}`} 
+          <div data-tip={`${congressMember.name} <br /> <strong>${translatedString(congressMember.rank, language)}</strong> <br /> ${translatedString(congressMember.affil, language)} <br /> ${translatedString('Representing', language)} ${congressMember.state}-${congressMember.district}`} 
                className={`ReportCard ${congressMember.affil} tooltip`}>
             <div>{congressMember.state}</div>
             <div>{congressMember.district}</div>
-            {/* <span class="tooltiptext">
-              <div>{congressMember.name}</div>
-              <div><strong>{congressMember.rank}</strong></div>
-              <div>{congressMember.affil}</div>
-              <div>{`Representing ${congressMember.state}`}</div>
-            </span> */}
           </div>
         </Link>
       )

--- a/src/pages/data/reports-es.mdx
+++ b/src/pages/data/reports-es.mdx
@@ -1,6 +1,7 @@
 import Layout from '../../components/Layout'
 import { DataPageSidebarLinks } from '../../helpers/constants'
 import CycleDiagramSpanish from "../../images/report-card-tracker-es.png"
+import ReportCardExplorer from '../../components/ReportCardExplorer';
 import { Link } from 'gatsby'
 
 <Layout pageTitle="Congressional Report Cards" sidebarLinks={DataPageSidebarLinks} activeHeaderLink="Data">
@@ -20,11 +21,7 @@ Para ver nuestro informe resumido de todos los distritos y estados analizados, c
 
 A continuación, ** coloque el cursor ** para ver el nombre y rango de un representante; ** haga clic ** para abrir un informe completo sobre la aplicación de la EPA en el distrito o estado del representante en español:
 
-<!--This is the main content file to edit for this page. It is embedded in src/pages/cd-reports.js-->
-
-<!--Content for the top of the page (above the data visualization) is in reports-top.md in this folder-->
-
-<!--The call-to-action text between the data visualization and the EEW icon is in reports-cta.md-->
+<ReportCardExplorer language='spanish'/>
 
 ### ¿Le preocupan estos datos?
 


### PR DESCRIPTION
### Report Card Explorer
* Update component to take a language prop
* Create a simple english to spanish dictionary for translated strings.
* Create string translation helper function

### Reports-es
* Update page to pass spanish language to report card explorer component
* Remove outdated comments