### PR TITLE
2023 report cards

### DIFF
--- a/src/helpers/house.js
+++ b/src/helpers/house.js
@@ -1,4 +1,4 @@
-[
+export const House = [
     {
         "name":"Robert B. Aderholt",
         "affil":"Republican",

--- a/src/helpers/house.js
+++ b/src/helpers/house.js
@@ -1,3068 +1,3089 @@
-﻿export const House = [
-  {
-    "name": "Robert B. Aderholt - TEST",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "04",
-    "url": "https://www.example.com"
-  },
-  {
-    "name": "Karen Bass",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "37",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA37_2021.pdf"
-  },
-  {
-    "name": "Gus M. Bilirakis",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL12_2021.pdf"
-  },
-  {
-    "name": "Sanford D. Bishop, Jr.",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA02_2021.pdf"
-  },
-  {
-    "name": "Earl Blumenauer",
-    "affil": "Democrat",
-    "state": "OR",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR03_2021.pdf"
-  },
-  {
-    "name": "Kevin Brady",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX08_2021.pdf"
-  },
-  {
-    "name": "Mo Brooks",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL05_2021.pdf"
-  },
-  {
-    "name": "Vern Buchanan",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL16_2021.pdf"
-  },
-  {
-    "name": "Larry Bucshon",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN08_2021.pdf"
-  },
-  {
-    "name": "Michael C. Burgess",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "26",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX26_2021.pdf"
-  },
-  {
-    "name": "G. K. Butterfield",
-    "affil": "Democrat",
-    "state": "NC",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC01_2021.pdf"
-  },
-  {
-    "name": "Ken Calvert",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "42",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA42_2021.pdf"
-  },
-  {
-    "name": "André Carson",
-    "affil": "Democrat",
-    "state": "IN",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN07_2021.pdf"
-  },
-  {
-    "name": "John R. Carter",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "31",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX31_2021.pdf"
-  },
-  {
-    "name": "Kathy Castor",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL14_2021.pdf"
-  },
-  {
-    "name": "Steve Chabot",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH01_2021.pdf"
-  },
-  {
-    "name": "Judy Chu",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "27",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA27_2021.pdf"
-  },
-  {
-    "name": "David N. Cicilline",
-    "affil": "Democrat",
-    "state": "RI",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/RI01_2021.pdf"
-  },
-  {
-    "name": "Yvette D. Clarke",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY09_2021.pdf"
-  },
-  {
-    "name": "Emanuel Cleaver",
-    "affil": "Democrat",
-    "state": "MO",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO05_2021.pdf"
-  },
-  {
-    "name": "James E. Clyburn",
-    "affil": "Democrat",
-    "state": "SC",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC06_2021.pdf"
-  },
-  {
-    "name": "Steve Cohen",
-    "affil": "Democrat",
-    "state": "TN",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN09_2021.pdf"
-  },
-  {
-    "name": "Tom Cole",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK04_2021.pdf"
-  },
-  {
-    "name": "Gerald E. Connolly",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA11_2021.pdf"
-  },
-  {
-    "name": "Jim Cooper",
-    "affil": "Democrat",
-    "state": "TN",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN05_2021.pdf"
-  },
-  {
-    "name": "Jim Costa",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA16_2021.pdf"
-  },
-  {
-    "name": "Joe Courtney",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT02_2021.pdf"
-  },
-  {
-    "name": "Eric A. \"Rick\" Crawford",
-    "affil": "Republican",
-    "state": "AR",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AR01_2021.pdf"
-  },
-  {
-    "name": "Henry Cuellar",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "28",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX28_2021.pdf"
-  },
-  {
-    "name": "Danny K. Davis",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL07_2021.pdf"
-  },
-  {
-    "name": "Peter A. DeFazio",
-    "affil": "Democrat",
-    "state": "OR",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR04_2021.pdf"
-  },
-  {
-    "name": "Diana DeGette",
-    "affil": "Democrat",
-    "state": "CO",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO01_2021.pdf"
-  },
-  {
-    "name": "Rosa L. DeLauro",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT03_2021.pdf"
-  },
-  {
-    "name": "Scott DesJarlais",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN04_2021.pdf"
-  },
-  {
-    "name": "Theodore E. Deutch",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "22",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL22_2021.pdf"
-  },
-  {
-    "name": "Mario Diaz-Balart",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "25",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL25_2021.pdf"
-  },
-  {
-    "name": "Lloyd Doggett",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "35",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX35_2021.pdf"
-  },
-  {
-    "name": "Michael F. Doyle",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "18",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA18_2021.pdf"
-  },
-  {
-    "name": "Jeff Duncan",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC03_2021.pdf"
-  },
-  {
-    "name": "Anna G. Eshoo",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "18",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA18_2021.pdf"
-  },
-  {
-    "name": "Charles J. \"Chuck\" Fleischmann",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN03_2021.pdf"
-  },
-  {
-    "name": "Jeff Fortenberry",
-    "affil": "Republican",
-    "state": "NE",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NE01_2021.pdf"
-  },
-  {
-    "name": "Virginia Foxx",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC05_2021.pdf"
-  },
-  {
-    "name": "John Garamendi",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA03_2021.pdf"
-  },
-  {
-    "name": "Bob Gibbs",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH07_2021.pdf"
-  },
-  {
-    "name": "Louie Gohmert",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX01_2021.pdf"
-  },
-  {
-    "name": "Paul A. Gosar",
-    "affil": "Republican",
-    "state": "AZ",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ04_2021.pdf"
-  },
-  {
-    "name": "Kay Granger",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX12_2021.pdf"
-  },
-  {
-    "name": "Sam Graves",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO06_2021.pdf"
-  },
-  {
-    "name": "Al Green",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX09_2021.pdf"
-  },
-  {
-    "name": "H. Morgan Griffith",
-    "affil": "Republican",
-    "state": "VA",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA09_2021.pdf"
-  },
-  {
-    "name": "Raúl M. Grijalva",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ03_2021.pdf"
-  },
-  {
-    "name": "Brett Guthrie",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY02_2021.pdf"
-  },
-  {
-    "name": "Andy Harris",
-    "affil": "Republican",
-    "state": "MD",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD01_2021.pdf"
-  },
-  {
-    "name": "Vicky Hartzler",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO04_2021.pdf"
-  },
-  {
-    "name": "Jaime Herrera Beutler",
-    "affil": "Republican",
-    "state": "WA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA03_2021.pdf"
-  },
-  {
-    "name": "Brian Higgins",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "26",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY26_2021.pdf"
-  },
-  {
-    "name": "James A. Himes",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT04_2021.pdf"
-  },
-  {
-    "name": "Steny H. Hoyer",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD05_2021.pdf"
-  },
-  {
-    "name": "Bill Huizenga",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI02_2021.pdf"
-  },
-  {
-    "name": "Sheila Jackson Lee",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "18",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX18_2021.pdf"
-  },
-  {
-    "name": "Bill Johnson",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH06_2021.pdf"
-  },
-  {
-    "name": "Eddie Bernice Johnson",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "30",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX30_2021.pdf"
-  },
-  {
-    "name": "Henry C. \"Hank\" Johnson, Jr.",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA04_2021.pdf"
-  },
-  {
-    "name": "Jim Jordan",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH04_2021.pdf"
-  },
-  {
-    "name": "Marcy Kaptur",
-    "affil": "Democrat",
-    "state": "OH",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH09_2021.pdf"
-  },
-  {
-    "name": "William R. Keating",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA09_2021.pdf"
-  },
-  {
-    "name": "Mike Kelly",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA16_2021.pdf"
-  },
-  {
-    "name": "Ron Kind",
-    "affil": "Democrat",
-    "state": "WI",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI03_2021.pdf"
-  },
-  {
-    "name": "Adam Kinzinger",
-    "affil": "Republican",
-    "state": "IL",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL16_2021.pdf"
-  },
-  {
-    "name": "Doug Lamborn",
-    "affil": "Republican",
-    "state": "CO",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO05_2021.pdf"
-  },
-  {
-    "name": "James R. Langevin",
-    "affil": "Democrat",
-    "state": "RI",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/RI02_2021.pdf"
-  },
-  {
-    "name": "Rick Larsen",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA02_2021.pdf"
-  },
-  {
-    "name": "John B. Larson",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT01_2021.pdf"
-  },
-  {
-    "name": "Robert E. Latta",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH05_2021.pdf"
-  },
-  {
-    "name": "Barbara Lee",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA13_2021.pdf"
-  },
-  {
-    "name": "Zoe Lofgren",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "19",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA19_2021.pdf"
-  },
-  {
-    "name": "Billy Long",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO07_2021.pdf"
-  },
-  {
-    "name": "Frank D. Lucas",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK03_2021.pdf"
-  },
-  {
-    "name": "Blaine Luetkemeyer",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO03_2021.pdf"
-  },
-  {
-    "name": "Stephen F. Lynch",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA08_2021.pdf"
-  },
-  {
-    "name": "Carolyn B. Maloney",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY12_2021.pdf"
-  },
-  {
-    "name": "Doris O. Matsui",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA06_2021.pdf"
-  },
-  {
-    "name": "Kevin McCarthy",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "23",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA23_2021.pdf"
-  },
-  {
-    "name": "Michael T. McCaul",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX10_2021.pdf"
-  },
-  {
-    "name": "Tom McClintock",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA04_2021.pdf"
-  },
-  {
-    "name": "Betty McCollum",
-    "affil": "Democrat",
-    "state": "MN",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN04_2021.pdf"
-  },
-  {
-    "name": "James P. McGovern",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA02_2021.pdf"
-  },
-  {
-    "name": "Patrick T. McHenry",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC10_2021.pdf"
-  },
-  {
-    "name": "David B. McKinley",
-    "affil": "Republican",
-    "state": "WV",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WV01_2021.pdf"
-  },
-  {
-    "name": "Cathy McMorris Rodgers",
-    "affil": "Republican",
-    "state": "WA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA05_2021.pdf"
-  },
-  {
-    "name": "Jerry McNerney",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA09_2021.pdf"
-  },
-  {
-    "name": "Gregory W. Meeks",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY05_2021.pdf"
-  },
-  {
-    "name": "Gwen Moore",
-    "affil": "Democrat",
-    "state": "WI",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI04_2021.pdf"
-  },
-  {
-    "name": "Jerrold Nadler",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY10_2021.pdf"
-  },
-  {
-    "name": "Grace F. Napolitano",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "32",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA32_2021.pdf"
-  },
-  {
-    "name": "Richard E. Neal",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA01_2021.pdf"
-  },
-  {
-    "name": "Eleanor Holmes Norton",
-    "affil": "Democrat",
-    "state": "DC",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/DC00_2021.pdf"
-  },
-  {
-    "name": "Devin Nunes",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "22",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA22_2021.pdf"
-  },
-  {
-    "name": "Steven M. Palazzo",
-    "affil": "Republican",
-    "state": "MS",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MS04_2021.pdf"
-  },
-  {
-    "name": "Frank Pallone, Jr.",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ06_2021.pdf"
-  },
-  {
-    "name": "Bill Pascrell, Jr.",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ09_2021.pdf"
-  },
-  {
-    "name": "Nancy Pelosi",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA12_2021.pdf"
-  },
-  {
-    "name": "Ed Perlmutter",
-    "affil": "Democrat",
-    "state": "CO",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO07_2021.pdf"
-  },
-  {
-    "name": "Chellie Pingree",
-    "affil": "Democrat",
-    "state": "ME",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ME01_2021.pdf"
-  },
-  {
-    "name": "Bill Posey",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL08_2021.pdf"
-  },
-  {
-    "name": "David E. Price",
-    "affil": "Democrat",
-    "state": "NC",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC04_2021.pdf"
-  },
-  {
-    "name": "Mike Quigley",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL05_2021.pdf"
-  },
-  {
-    "name": "Tom Reed",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "23",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY23_2021.pdf"
-  },
-  {
-    "name": "Harold Rogers",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY05_2021.pdf"
-  },
-  {
-    "name": "Mike Rogers",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL03_2021.pdf"
-  },
-  {
-    "name": "Lucille Roybal-Allard",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "40",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA40_2021.pdf"
-  },
-  {
-    "name": "C. A. Dutch Ruppersberger",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD02_2021.pdf"
-  },
-  {
-    "name": "Bobby L. Rush",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL01_2021.pdf"
-  },
-  {
-    "name": "Tim Ryan",
-    "affil": "Democrat",
-    "state": "OH",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH13_2021.pdf"
-  },
-  {
-    "name": "Gregorio Kilili Camacho Sablan",
-    "affil": "Democrat",
-    "state": "MP",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MP00_2021.pdf"
-  },
-  {
-    "name": "John P. Sarbanes",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD03_2021.pdf"
-  },
-  {
-    "name": "Steve Scalise",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA01_2021.pdf"
-  },
-  {
-    "name": "Janice D. Schakowsky",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL09_2021.pdf"
-  },
-  {
-    "name": "Adam B. Schiff",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "28",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA28_2021.pdf"
-  },
-  {
-    "name": "Kurt Schrader",
-    "affil": "Democrat",
-    "state": "OR",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR05_2021.pdf"
-  },
-  {
-    "name": "David Schweikert",
-    "affil": "Republican",
-    "state": "AZ",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ06_2021.pdf"
-  },
-  {
-    "name": "Austin Scott",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA08_2021.pdf"
-  },
-  {
-    "name": "David Scott",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA13_2021.pdf"
-  },
-  {
-    "name": "Robert C. \"Bobby\" Scott",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA03_2021.pdf"
-  },
-  {
-    "name": "Terri Sewell",
-    "affil": "Democrat",
-    "state": "AL",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL07_2021.pdf"
-  },
-  {
-    "name": "Brad Sherman",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "30",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA30_2021.pdf"
-  },
-  {
-    "name": "Michael K. Simpson",
-    "affil": "Republican",
-    "state": "ID",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ID02_2021.pdf"
-  },
-  {
-    "name": "Albio Sires",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ08_2021.pdf"
-  },
-  {
-    "name": "Adam Smith",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA09_2021.pdf"
-  },
-  {
-    "name": "Adrian Smith",
-    "affil": "Republican",
-    "state": "NE",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NE03_2021.pdf"
-  },
-  {
-    "name": "Christopher H. Smith",
-    "affil": "Republican",
-    "state": "NJ",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ04_2021.pdf"
-  },
-  {
-    "name": "Jackie Speier",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA14_2021.pdf"
-  },
-  {
-    "name": "Linda T. Sánchez",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "38",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA38_2021.pdf"
-  },
-  {
-    "name": "Bennie G. Thompson",
-    "affil": "Democrat",
-    "state": "MS",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MS02_2021.pdf"
-  },
-  {
-    "name": "Mike Thompson",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA05_2021.pdf"
-  },
-  {
-    "name": "Glenn Thompson",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "15",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA15_2021.pdf"
-  },
-  {
-    "name": "Paul Tonko",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "20",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY20_2021.pdf"
-  },
-  {
-    "name": "Michael R. Turner",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH10_2021.pdf"
-  },
-  {
-    "name": "Fred Upton",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI06_2021.pdf"
-  },
-  {
-    "name": "Nydia M. Velázquez",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY07_2021.pdf"
-  },
-  {
-    "name": "Tim Walberg",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI07_2021.pdf"
-  },
-  {
-    "name": "Debbie Wasserman Schultz",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "23",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL23_2021.pdf"
-  },
-  {
-    "name": "Maxine Waters",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "43",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA43_2021.pdf"
-  },
-  {
-    "name": "Daniel Webster",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL11_2021.pdf"
-  },
-  {
-    "name": "Peter Welch",
-    "affil": "Democrat",
-    "state": "VT",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VT00_2021.pdf"
-  },
-  {
-    "name": "Joe Wilson",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC02_2021.pdf"
-  },
-  {
-    "name": "Frederica S. Wilson",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "24",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL24_2021.pdf"
-  },
-  {
-    "name": "Robert J. Wittman",
-    "affil": "Republican",
-    "state": "VA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA01_2021.pdf"
-  },
-  {
-    "name": "Steve Womack",
-    "affil": "Republican",
-    "state": "AR",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AR03_2021.pdf"
-  },
-  {
-    "name": "John A. Yarmuth",
-    "affil": "Democrat",
-    "state": "KY",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY03_2021.pdf"
-  },
-  {
-    "name": "Don Young",
-    "affil": "Republican",
-    "state": "AK",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AK00_2021.pdf"
-  },
-  {
-    "name": "Mark E. Amodei",
-    "affil": "Republican",
-    "state": "NV",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NV02_2021.pdf"
-  },
-  {
-    "name": "Suzanne Bonamici",
-    "affil": "Democrat",
-    "state": "OR",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR01_2021.pdf"
-  },
-  {
-    "name": "Suzan K. DelBene",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA01_2021.pdf"
-  },
-  {
-    "name": "Thomas Massie",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY04_2021.pdf"
-  },
-  {
-    "name": "Donald M. Payne, Jr.",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ10_2021.pdf"
-  },
-  {
-    "name": "Bill Foster",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL11_2021.pdf"
-  },
-  {
-    "name": "Dina Titus",
-    "affil": "Democrat",
-    "state": "NV",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NV01_2021.pdf"
-  },
-  {
-    "name": "Doug LaMalfa",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA01_2021.pdf"
-  },
-  {
-    "name": "Jared Huffman",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA02_2021.pdf"
-  },
-  {
-    "name": "Ami Bera",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA07_2021.pdf"
-  },
-  {
-    "name": "Eric Swalwell",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "15",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA15_2021.pdf"
-  },
-  {
-    "name": "Julia Brownley",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "26",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA26_2021.pdf"
-  },
-  {
-    "name": "Tony Cárdenas",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "29",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA29_2021.pdf"
-  },
-  {
-    "name": "Raul Ruiz",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "36",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA36_2021.pdf"
-  },
-  {
-    "name": "Mark Takano",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "41",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA41_2021.pdf"
-  },
-  {
-    "name": "Alan S. Lowenthal",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "47",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA47_2021.pdf"
-  },
-  {
-    "name": "Juan Vargas",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "51",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA51_2021.pdf"
-  },
-  {
-    "name": "Scott H. Peters",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "52",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA52_2021.pdf"
-  },
-  {
-    "name": "Lois Frankel",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "21",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL21_2021.pdf"
-  },
-  {
-    "name": "Rodney Davis",
-    "affil": "Republican",
-    "state": "IL",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL13_2021.pdf"
-  },
-  {
-    "name": "Cheri Bustos",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "17",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL17_2021.pdf"
-  },
-  {
-    "name": "Jackie Walorski",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN02_2021.pdf"
-  },
-  {
-    "name": "Andy Barr",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY06_2021.pdf"
-  },
-  {
-    "name": "Daniel T. Kildee",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI05_2021.pdf"
-  },
-  {
-    "name": "Ann Wagner",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO02_2021.pdf"
-  },
-  {
-    "name": "Richard Hudson",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC08_2021.pdf"
-  },
-  {
-    "name": "Ann Kuster",
-    "affil": "Democrat",
-    "state": "NH",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NH02_2021.pdf"
-  },
-  {
-    "name": "Grace Meng",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY06_2021.pdf"
-  },
-  {
-    "name": "Hakeem S. Jeffries",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY08_2021.pdf"
-  },
-  {
-    "name": "Sean Patrick Maloney",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "18",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY18_2021.pdf"
-  },
-  {
-    "name": "Brad R. Wenstrup",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH02_2021.pdf"
-  },
-  {
-    "name": "Joyce Beatty",
-    "affil": "Democrat",
-    "state": "OH",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH03_2021.pdf"
-  },
-  {
-    "name": "David P. Joyce",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH14_2021.pdf"
-  },
-  {
-    "name": "Markwayne Mullin",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK02_2021.pdf"
-  },
-  {
-    "name": "Scott Perry",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA10_2021.pdf"
-  },
-  {
-    "name": "Matt Cartwright",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA08_2021.pdf"
-  },
-  {
-    "name": "Tom Rice",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC07_2021.pdf"
-  },
-  {
-    "name": "Randy K. Weber, Sr.",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX14_2021.pdf"
-  },
-  {
-    "name": "Joaquin Castro",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "20",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX20_2021.pdf"
-  },
-  {
-    "name": "Roger Williams",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "25",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX25_2021.pdf"
-  },
-  {
-    "name": "Marc A. Veasey",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "33",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX33_2021.pdf"
-  },
-  {
-    "name": "Filemon Vela",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "34",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX34_2021.pdf"
-  },
-  {
-    "name": "Chris Stewart",
-    "affil": "Republican",
-    "state": "UT",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/UT02_2021.pdf"
-  },
-  {
-    "name": "Derek Kilmer",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA06_2021.pdf"
-  },
-  {
-    "name": "Mark Pocan",
-    "affil": "Democrat",
-    "state": "WI",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI02_2021.pdf"
-  },
-  {
-    "name": "Robin L. Kelly",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL02_2021.pdf"
-  },
-  {
-    "name": "Jason Smith",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO08_2021.pdf"
-  },
-  {
-    "name": "Katherine M. Clark",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA05_2021.pdf"
-  },
-  {
-    "name": "Donald Norcross",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ01_2021.pdf"
-  },
-  {
-    "name": "Alma S. Adams",
-    "affil": "Democrat",
-    "state": "NC",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC12_2021.pdf"
-  },
-  {
-    "name": "Gary J. Palmer",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL06_2021.pdf"
-  },
-  {
-    "name": "J. Hill",
-    "affil": "Republican",
-    "state": "AR",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AR02_2021.pdf"
-  },
-  {
-    "name": "Bruce Westerman",
-    "affil": "Republican",
-    "state": "AR",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AR04_2021.pdf"
-  },
-  {
-    "name": "Ruben Gallego",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ07_2021.pdf"
-  },
-  {
-    "name": "Mark DeSaulnier",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA11_2021.pdf"
-  },
-  {
-    "name": "Pete Aguilar",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "31",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA31_2021.pdf"
-  },
-  {
-    "name": "Ted Lieu",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "33",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA33_2021.pdf"
-  },
-  {
-    "name": "Norma J. Torres",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "35",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA35_2021.pdf"
-  },
-  {
-    "name": "Ken Buck",
-    "affil": "Republican",
-    "state": "CO",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO04_2021.pdf"
-  },
-  {
-    "name": "Earl L. \"Buddy\" Carter",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA01_2021.pdf"
-  },
-  {
-    "name": "Jody B. Hice",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA10_2021.pdf"
-  },
-  {
-    "name": "Barry Loudermilk",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA11_2021.pdf"
-  },
-  {
-    "name": "Rick W. Allen",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA12_2021.pdf"
-  },
-  {
-    "name": "Mike Bost",
-    "affil": "Republican",
-    "state": "IL",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL12_2021.pdf"
-  },
-  {
-    "name": "Garret Graves",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA06_2021.pdf"
-  },
-  {
-    "name": "Seth Moulton",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA06_2021.pdf"
-  },
-  {
-    "name": "John R. Moolenaar",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI04_2021.pdf"
-  },
-  {
-    "name": "Debbie Dingell",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI12_2021.pdf"
-  },
-  {
-    "name": "Brenda L. Lawrence",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI14_2021.pdf"
-  },
-  {
-    "name": "Tom Emmer",
-    "affil": "Republican",
-    "state": "MN",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN06_2021.pdf"
-  },
-  {
-    "name": "David Rouzer",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC07_2021.pdf"
-  },
-  {
-    "name": "Bonnie Watson Coleman",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ12_2021.pdf"
-  },
-  {
-    "name": "Lee M. Zeldin",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY01_2021.pdf"
-  },
-  {
-    "name": "Kathleen M. Rice",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY04_2021.pdf"
-  },
-  {
-    "name": "Elise M. Stefanik",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "21",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY21_2021.pdf"
-  },
-  {
-    "name": "John Katko",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "24",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY24_2021.pdf"
-  },
-  {
-    "name": "Brendan F. Boyle",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA02_2021.pdf"
-  },
-  {
-    "name": "Brian Babin",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "36",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX36_2021.pdf"
-  },
-  {
-    "name": "Donald S. Beyer, Jr.",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA08_2021.pdf"
-  },
-  {
-    "name": "Stacey E. Plaskett",
-    "affil": "Democrat",
-    "state": "VI",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VI00_2021.pdf"
-  },
-  {
-    "name": "Dan Newhouse",
-    "affil": "Republican",
-    "state": "WA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA04_2021.pdf"
-  },
-  {
-    "name": "Glenn Grothman",
-    "affil": "Republican",
-    "state": "WI",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI06_2021.pdf"
-  },
-  {
-    "name": "Alexander Mooney",
-    "affil": "Republican",
-    "state": "WV",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WV02_2021.pdf"
-  },
-  {
-    "name": "Aumua Amata Coleman Radewagen",
-    "affil": "Republican",
-    "state": "AS",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AS00_2021.pdf"
-  },
-  {
-    "name": "Trent Kelly",
-    "affil": "Republican",
-    "state": "MS",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MS01_2021.pdf"
-  },
-  {
-    "name": "Darin LaHood",
-    "affil": "Republican",
-    "state": "IL",
-    "district": "18",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL18_2021.pdf"
-  },
-  {
-    "name": "Warren Davidson",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH08_2021.pdf"
-  },
-  {
-    "name": "James Comer",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY01_2021.pdf"
-  },
-  {
-    "name": "Dwight Evans",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA03_2021.pdf"
-  },
-  {
-    "name": "Bradley Scott Schneider",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL10_2021.pdf"
-  },
-  {
-    "name": "Tom O’Halleran",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ01_2021.pdf"
-  },
-  {
-    "name": "Andy Biggs",
-    "affil": "Republican",
-    "state": "AZ",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ05_2021.pdf"
-  },
-  {
-    "name": "Ro Khanna",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "17",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA17_2021.pdf"
-  },
-  {
-    "name": "Jimmy Panetta",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "20",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA20_2021.pdf"
-  },
-  {
-    "name": "Salud O. Carbajal",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "24",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA24_2021.pdf"
-  },
-  {
-    "name": "Nanette Diaz Barragán",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "44",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA44_2021.pdf"
-  },
-  {
-    "name": "J. Luis Correa",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "46",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA46_2021.pdf"
-  },
-  {
-    "name": "Lisa Blunt Rochester",
-    "affil": "Democrat",
-    "state": "DE",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/DE00_2021.pdf"
-  },
-  {
-    "name": "Matt Gaetz",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL01_2021.pdf"
-  },
-  {
-    "name": "Neal P. Dunn",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL02_2021.pdf"
-  },
-  {
-    "name": "John H. Rutherford",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL04_2021.pdf"
-  },
-  {
-    "name": "Al Lawson, Jr.",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL05_2021.pdf"
-  },
-  {
-    "name": "Stephanie N. Murphy",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL07_2021.pdf"
-  },
-  {
-    "name": "Darren Soto",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL09_2021.pdf"
-  },
-  {
-    "name": "Val Butler Demings",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL10_2021.pdf"
-  },
-  {
-    "name": "Charlie Crist",
-    "affil": "Democrat",
-    "state": "FL",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL13_2021.pdf"
-  },
-  {
-    "name": "Brian J. Mast",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "18",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL18_2021.pdf"
-  },
-  {
-    "name": "A. Drew Ferguson IV",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA03_2021.pdf"
-  },
-  {
-    "name": "Raja Krishnamoorthi",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL08_2021.pdf"
-  },
-  {
-    "name": "Jim Banks",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN03_2021.pdf"
-  },
-  {
-    "name": "Trey Hollingsworth",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN09_2021.pdf"
-  },
-  {
-    "name": "Clay Higgins",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA03_2021.pdf"
-  },
-  {
-    "name": "Mike Johnson",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA04_2021.pdf"
-  },
-  {
-    "name": "Anthony Brown",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD04_2021.pdf"
-  },
-  {
-    "name": "Jamie Raskin",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD08_2021.pdf"
-  },
-  {
-    "name": "Jack Bergman",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI01_2021.pdf"
-  },
-  {
-    "name": "Ted Budd",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC13_2021.pdf"
-  },
-  {
-    "name": "Don Bacon",
-    "affil": "Republican",
-    "state": "NE",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NE02_2021.pdf"
-  },
-  {
-    "name": "Josh Gottheimer",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ05_2021.pdf"
-  },
-  {
-    "name": "Thomas R. Suozzi",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY03_2021.pdf"
-  },
-  {
-    "name": "Adriano Espaillat",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY13_2021.pdf"
-  },
-  {
-    "name": "Brian K. Fitzpatrick",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA01_2021.pdf"
-  },
-  {
-    "name": "Lloyd Smucker",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA11_2021.pdf"
-  },
-  {
-    "name": "Jenniffer González-Colón",
-    "affil": "Republican",
-    "state": "PR",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PR00_2021.pdf"
-  },
-  {
-    "name": "David Kustoff",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN08_2021.pdf"
-  },
-  {
-    "name": "Vicente Gonzalez",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "15",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX15_2021.pdf"
-  },
-  {
-    "name": "Jodey C. Arrington",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "19",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX19_2021.pdf"
-  },
-  {
-    "name": "A. Donald McEachin",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA04_2021.pdf"
-  },
-  {
-    "name": "Pramila Jayapal",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA07_2021.pdf"
-  },
-  {
-    "name": "Mike Gallagher",
-    "affil": "Republican",
-    "state": "WI",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI08_2021.pdf"
-  },
-  {
-    "name": "Liz Cheney",
-    "affil": "Republican",
-    "state": "WY",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WY00_2021.pdf"
-  },
-  {
-    "name": "Ron Estes",
-    "affil": "Republican",
-    "state": "KS",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KS04_2021.pdf"
-  },
-  {
-    "name": "Ralph Norman",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC05_2021.pdf"
-  },
-  {
-    "name": "Jimmy Gomez",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "34",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA34_2021.pdf"
-  },
-  {
-    "name": "John R. Curtis",
-    "affil": "Republican",
-    "state": "UT",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/UT03_2021.pdf"
-  },
-  {
-    "name": "Conor Lamb",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "17",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA17_2021.pdf"
-  },
-  {
-    "name": "Debbie Lesko",
-    "affil": "Republican",
-    "state": "AZ",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ08_2021.pdf"
-  },
-  {
-    "name": "Michael Cloud",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "27",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX27_2021.pdf"
-  },
-  {
-    "name": "Troy Balderson",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH12_2021.pdf"
-  },
-  {
-    "name": "Kevin Hern",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK01_2021.pdf"
-  },
-  {
-    "name": "Joseph D. Morelle",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "25",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY25_2021.pdf"
-  },
-  {
-    "name": "Mary Gay Scanlon",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA05_2021.pdf"
-  },
-  {
-    "name": "Susan Wild",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA07_2021.pdf"
-  },
-  {
-    "name": "Ed Case",
-    "affil": "Democrat",
-    "state": "HI",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/HI01_2021.pdf"
-  },
-  {
-    "name": "Steven Horsford",
-    "affil": "Democrat",
-    "state": "NV",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NV04_2021.pdf"
-  },
-  {
-    "name": "Ann Kirkpatrick",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ02_2021.pdf"
-  },
-  {
-    "name": "Greg Stanton",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ09_2021.pdf"
-  },
-  {
-    "name": "Josh Harder",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA10_2021.pdf"
-  },
-  {
-    "name": "Katie Porter",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "45",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA45_2021.pdf"
-  },
-  {
-    "name": "Mike Levin",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "49",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA49_2021.pdf"
-  },
-  {
-    "name": "Joe Neguse",
-    "affil": "Democrat",
-    "state": "CO",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO02_2021.pdf"
-  },
-  {
-    "name": "Jason Crow",
-    "affil": "Democrat",
-    "state": "CO",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO06_2021.pdf"
-  },
-  {
-    "name": "Jahana Hayes",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT05_2021.pdf"
-  },
-  {
-    "name": "Michael Waltz",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL06_2021.pdf"
-  },
-  {
-    "name": "W. Gregory Steube",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "17",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL17_2021.pdf"
-  },
-  {
-    "name": "Lucy McBath",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA06_2021.pdf"
-  },
-  {
-    "name": "Michael F. Q. San Nicolas",
-    "affil": "Democrat",
-    "state": "GU",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GU00_2021.pdf"
-  },
-  {
-    "name": "Cynthia Axne",
-    "affil": "Democrat",
-    "state": "IA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IA03_2021.pdf"
-  },
-  {
-    "name": "Russ Fulcher",
-    "affil": "Republican",
-    "state": "ID",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ID01_2021.pdf"
-  },
-  {
-    "name": "Jesús G. \"Chuy\" García",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL04_2021.pdf"
-  },
-  {
-    "name": "Sean Casten",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL06_2021.pdf"
-  },
-  {
-    "name": "Lauren Underwood",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL14_2021.pdf"
-  },
-  {
-    "name": "James R. Baird",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN04_2021.pdf"
-  },
-  {
-    "name": "Greg Pence",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN06_2021.pdf"
-  },
-  {
-    "name": "Sharice Davids",
-    "affil": "Democrat",
-    "state": "KS",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KS03_2021.pdf"
-  },
-  {
-    "name": "Lori Trahan",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA03_2021.pdf"
-  },
-  {
-    "name": "Ayanna Pressley",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA07_2021.pdf"
-  },
-  {
-    "name": "David J. Trone",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD06_2021.pdf"
-  },
-  {
-    "name": "Elissa Slotkin",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI08_2021.pdf"
-  },
-  {
-    "name": "Andy Levin",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI09_2021.pdf"
-  },
-  {
-    "name": "Haley M. Stevens",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI11_2021.pdf"
-  },
-  {
-    "name": "Rashida Tlaib",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI13_2021.pdf"
-  },
-  {
-    "name": "Jim Hagedorn",
-    "affil": "Republican",
-    "state": "MN",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN01_2021.pdf"
-  },
-  {
-    "name": "Angie Craig",
-    "affil": "Democrat",
-    "state": "MN",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN02_2021.pdf"
-  },
-  {
-    "name": "Dean Phillips",
-    "affil": "Democrat",
-    "state": "MN",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN03_2021.pdf"
-  },
-  {
-    "name": "Ilhan Omar",
-    "affil": "Democrat",
-    "state": "MN",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN05_2021.pdf"
-  },
-  {
-    "name": "Pete Stauber",
-    "affil": "Republican",
-    "state": "MN",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN08_2021.pdf"
-  },
-  {
-    "name": "Michael Guest",
-    "affil": "Republican",
-    "state": "MS",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MS03_2021.pdf"
-  },
-  {
-    "name": "Kelly Armstrong",
-    "affil": "Republican",
-    "state": "ND",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ND00_2021.pdf"
-  },
-  {
-    "name": "Chris Pappas",
-    "affil": "Democrat",
-    "state": "NH",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NH01_2021.pdf"
-  },
-  {
-    "name": "Jefferson Van Drew",
-    "affil": "Republican",
-    "state": "NJ",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ02_2021.pdf"
-  },
-  {
-    "name": "Andy Kim",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ03_2021.pdf"
-  },
-  {
-    "name": "Tom Malinowski",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ07_2021.pdf"
-  },
-  {
-    "name": "Mikie Sherrill",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ11_2021.pdf"
-  },
-  {
-    "name": "Susie Lee",
-    "affil": "Democrat",
-    "state": "NV",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NV03_2021.pdf"
-  },
-  {
-    "name": "Alexandria Ocasio-Cortez",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY14_2021.pdf"
-  },
-  {
-    "name": "Antonio Delgado",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "19",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY19_2021.pdf"
-  },
-  {
-    "name": "Anthony Gonzalez",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH16_2021.pdf"
-  },
-  {
-    "name": "Madeleine Dean",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA04_2021.pdf"
-  },
-  {
-    "name": "Chrissy Houlahan",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA06_2021.pdf"
-  },
-  {
-    "name": "Daniel Meuser",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA09_2021.pdf"
-  },
-  {
-    "name": "John Joyce",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA13_2021.pdf"
-  },
-  {
-    "name": "Guy Reschenthaler",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA14_2021.pdf"
-  },
-  {
-    "name": "William R. Timmons IV",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC04_2021.pdf"
-  },
-  {
-    "name": "Dusty Johnson",
-    "affil": "Republican",
-    "state": "SD",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SD00_2021.pdf"
-  },
-  {
-    "name": "Tim Burchett",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN02_2021.pdf"
-  },
-  {
-    "name": "John Rose",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN06_2021.pdf"
-  },
-  {
-    "name": "Mark E. Green",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN07_2021.pdf"
-  },
-  {
-    "name": "Dan Crenshaw",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX02_2021.pdf"
-  },
-  {
-    "name": "Van Taylor",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX03_2021.pdf"
-  },
-  {
-    "name": "Lance Gooden",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX05_2021.pdf"
-  },
-  {
-    "name": "Lizzie Fletcher",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX07_2021.pdf"
-  },
-  {
-    "name": "Veronica Escobar",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX16_2021.pdf"
-  },
-  {
-    "name": "Chip Roy",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "21",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX21_2021.pdf"
-  },
-  {
-    "name": "Sylvia R. Garcia",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "29",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX29_2021.pdf"
-  },
-  {
-    "name": "Colin Z. Allred",
-    "affil": "Democrat",
-    "state": "TX",
-    "district": "32",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX32_2021.pdf"
-  },
-  {
-    "name": "Elaine G. Luria",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA02_2021.pdf"
-  },
-  {
-    "name": "Ben Cline",
-    "affil": "Republican",
-    "state": "VA",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA06_2021.pdf"
-  },
-  {
-    "name": "Abigail Davis Spanberger",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA07_2021.pdf"
-  },
-  {
-    "name": "Jennifer Wexton",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA10_2021.pdf"
-  },
-  {
-    "name": "Kim Schrier",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA08_2021.pdf"
-  },
-  {
-    "name": "Bryan Steil",
-    "affil": "Republican",
-    "state": "WI",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI01_2021.pdf"
-  },
-  {
-    "name": "Carol D. Miller",
-    "affil": "Republican",
-    "state": "WV",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WV03_2021.pdf"
-  },
-  {
-    "name": "Jared F. Golden",
-    "affil": "Democrat",
-    "state": "ME",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ME02_2021.pdf"
-  },
-  {
-    "name": "Fred Keller",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "12",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA12_2021.pdf"
-  },
-  {
-    "name": "Dan Bishop",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC09_2021.pdf"
-  },
-  {
-    "name": "Gregory F. Murphy",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC03_2021.pdf"
-  },
-  {
-    "name": "Kweisi Mfume",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD07_2021.pdf"
-  },
-  {
-    "name": "Thomas P. Tiffany",
-    "affil": "Republican",
-    "state": "WI",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI07_2021.pdf"
-  },
-  {
-    "name": "Mike Garcia",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "25",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA25_2021.pdf"
-  },
-  {
-    "name": "Chris Jacobs",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "27",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY27_2021.pdf"
-  },
-  {
-    "name": "Darrell Issa",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "50",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA50_2021.pdf"
-  },
-  {
-    "name": "Pete Sessions",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "17",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX17_2021.pdf"
-  },
-  {
-    "name": "David G. Valadao",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "21",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA21_2021.pdf"
-  },
-  {
-    "name": "Jerry L. Carl",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL01_2021.pdf"
-  },
-  {
-    "name": "Barry Moore",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL02_2021.pdf"
-  },
-  {
-    "name": "Jay Obernolte",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "08",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA08_2021.pdf"
-  },
-  {
-    "name": "Young Kim",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "39",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA39_2021.pdf"
-  },
-  {
-    "name": "Michelle Steel",
-    "affil": "Republican",
-    "state": "CA",
-    "district": "48",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA48_2021.pdf"
-  },
-  {
-    "name": "Sara Jacobs",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "53",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA53_2021.pdf"
-  },
-  {
-    "name": "Lauren Boebert",
-    "affil": "Republican",
-    "state": "CO",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO03_2021.pdf"
-  },
-  {
-    "name": "Kat Cammack",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL03_2021.pdf"
-  },
-  {
-    "name": "C. Scott Franklin",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "15",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL15_2021.pdf"
-  },
-  {
-    "name": "Byron Donalds",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "19",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL19_2021.pdf"
-  },
-  {
-    "name": "Carlos A. Gimenez",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "26",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL26_2021.pdf"
-  },
-  {
-    "name": "Maria Elvira Salazar",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "27",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL27_2021.pdf"
-  },
-  {
-    "name": "Nikema Williams",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA05_2021.pdf"
-  },
-  {
-    "name": "Carolyn Bourdeaux",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA07_2021.pdf"
-  },
-  {
-    "name": "Andrew S. Clyde",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "09",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA09_2021.pdf"
-  },
-  {
-    "name": "Marjorie Taylor Greene",
-    "affil": "Republican",
-    "state": "GA",
-    "district": "14",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA14_2021.pdf"
-  },
-  {
-    "name": "Kaiali’i Kahele",
-    "affil": "Democrat",
-    "state": "HI",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/HI02_2021.pdf"
-  },
-  {
-    "name": "Ashley Hinson",
-    "affil": "Republican",
-    "state": "IA",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IA01_2021.pdf"
-  },
-  {
-    "name": "Mariannette Miller-Meeks",
-    "affil": "Republican",
-    "state": "IA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IA02_2021.pdf"
-  },
-  {
-    "name": "Randy Feenstra",
-    "affil": "Republican",
-    "state": "IA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IA04_2021.pdf"
-  },
-  {
-    "name": "Marie Newman",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL03_2021.pdf"
-  },
-  {
-    "name": "Mary E. Miller",
-    "affil": "Republican",
-    "state": "IL",
-    "district": "15",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL15_2021.pdf"
-  },
-  {
-    "name": "Frank J. Mrvan",
-    "affil": "Democrat",
-    "state": "IN",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN01_2021.pdf"
-  },
-  {
-    "name": "Victoria Spartz",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN05_2021.pdf"
-  },
-  {
-    "name": "Tracey Mann",
-    "affil": "Republican",
-    "state": "KS",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KS01_2021.pdf"
-  },
-  {
-    "name": "Jake LaTurner",
-    "affil": "Republican",
-    "state": "KS",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KS02_2021.pdf"
-  },
-  {
-    "name": "Jake Auchincloss",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA04_2021.pdf"
-  },
-  {
-    "name": "Peter Meijer",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI03_2021.pdf"
-  },
-  {
-    "name": "Lisa C. McClain",
-    "affil": "Republican",
-    "state": "MI",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI10_2021.pdf"
-  },
-  {
-    "name": "Michelle Fischbach",
-    "affil": "Republican",
-    "state": "MN",
-    "district": "07",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN07_2021.pdf"
-  },
-  {
-    "name": "Cori Bush",
-    "affil": "Democrat",
-    "state": "MO",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO01_2021.pdf"
-  },
-  {
-    "name": "Matthew M. Rosendale",
-    "affil": "Republican",
-    "state": "MT",
-    "district": "00",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MT00_2021.pdf"
-  },
-  {
-    "name": "Deborah K. Ross",
-    "affil": "Democrat",
-    "state": "NC",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC02_2021.pdf"
-  },
-  {
-    "name": "Kathy E. Manning",
-    "affil": "Democrat",
-    "state": "NC",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC06_2021.pdf"
-  },
-  {
-    "name": "Madison Cawthorn",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC11_2021.pdf"
-  },
-  {
-    "name": "Yvette Herrell",
-    "affil": "Republican",
-    "state": "NM",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NM02_2021.pdf"
-  },
-  {
-    "name": "Teresa Leger Fernandez",
-    "affil": "Democrat",
-    "state": "NM",
-    "district": "03",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NM03_2021.pdf"
-  },
-  {
-    "name": "Andrew R. Garbarino",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY02_2021.pdf"
-  },
-  {
-    "name": "Nicole Malliotakis",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY11_2021.pdf"
-  },
-  {
-    "name": "Ritchie Torres",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "15",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY15_2021.pdf"
-  },
-  {
-    "name": "Jamaal Bowman",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "16",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY16_2021.pdf"
-  },
-  {
-    "name": "Mondaire Jones",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "17",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY17_2021.pdf"
-  },
-  {
-    "name": "Stephanie I. Bice",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK05_2021.pdf"
-  },
-  {
-    "name": "Cliff Bentz",
-    "affil": "Republican",
-    "state": "OR",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR02_2021.pdf"
-  },
-  {
-    "name": "Nancy Mace",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC01_2021.pdf"
-  },
-  {
-    "name": "Diana Harshbarger",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN01_2021.pdf"
-  },
-  {
-    "name": "Pat Fallon",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX04_2021.pdf"
-  },
-  {
-    "name": "August Pfluger",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "11",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX11_2021.pdf"
-  },
-  {
-    "name": "Ronny Jackson",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "13",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX13_2021.pdf"
-  },
-  {
-    "name": "Troy E. Nehls",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "22",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX22_2021.pdf"
-  },
-  {
-    "name": "Tony Gonzales",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "23",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX23_2021.pdf"
-  },
-  {
-    "name": "Beth Van Duyne",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "24",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX24_2021.pdf"
-  },
-  {
-    "name": "Blake D. Moore",
-    "affil": "Republican",
-    "state": "UT",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/UT01_2021.pdf"
-  },
-  {
-    "name": "Burgess Owens",
-    "affil": "Republican",
-    "state": "UT",
-    "district": "04",
-    "url": "https://environmentalenforcementwatch.org/report_cards/UT04_2021.pdf"
-  },
-  {
-    "name": "Bob Good",
-    "affil": "Republican",
-    "state": "VA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA05_2021.pdf"
-  },
-  {
-    "name": "Marilyn Strickland",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "10",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA10_2021.pdf"
-  },
-  {
-    "name": "Scott Fitzgerald",
-    "affil": "Republican",
-    "state": "WI",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI05_2021.pdf"
-  },
-  {
-    "name": "Claudia Tenney",
-    "affil": "Republican",
-    "state": "NY",
-    "district": "22",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY22_2021.pdf"
-  },
-  {
-    "name": "Julia Letlow",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "05",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA05_2021.pdf"
-  },
-  {
-    "name": "Troy A. Carter",
-    "affil": "Democrat",
-    "state": "LA",
-    "district": "02",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA02_2021.pdf"
-  },
-  {
-    "name": "Melanie A. Stansbury",
-    "affil": "Democrat",
-    "state": "NM",
-    "district": "01",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NM01_2021.pdf"
-  },
-  {
-    "name": "Jake Ellzey",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "06",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX06_2021.pdf"
-  }
+[
+    {
+        "name":"Robert B. Aderholt",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL04_2023.pdf"
+    },
+    {
+        "name":"Gus M. Bilirakis",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL12_2023.pdf"
+    },
+    {
+        "name":"Sanford D. Bishop, Jr.",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA02_2023.pdf"
+    },
+    {
+        "name":"Earl Blumenauer",
+        "affil":"Democrat",
+        "state":"OR",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR03_2023.pdf"
+    },
+    {
+        "name":"Vern Buchanan",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"16",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL16_2023.pdf"
+    },
+    {
+        "name":"Larry Bucshon",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN08_2023.pdf"
+    },
+    {
+        "name":"Michael C. Burgess",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"26",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX26_2023.pdf"
+    },
+    {
+        "name":"Ken Calvert",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"41",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA41_2023.pdf"
+    },
+    {
+        "name":"Andr\u00e9 Carson",
+        "affil":"Democrat",
+        "state":"IN",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN07_2023.pdf"
+    },
+    {
+        "name":"John R. Carter",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"31",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX31_2023.pdf"
+    },
+    {
+        "name":"Kathy Castor",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL14_2023.pdf"
+    },
+    {
+        "name":"Judy Chu",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"28",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA28_2023.pdf"
+    },
+    {
+        "name":"David N. Cicilline",
+        "affil":"Democrat",
+        "state":"RI",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/RI01_2023.pdf"
+    },
+    {
+        "name":"Yvette D. Clarke",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY09_2023.pdf"
+    },
+    {
+        "name":"Emanuel Cleaver",
+        "affil":"Democrat",
+        "state":"MO",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO05_2023.pdf"
+    },
+    {
+        "name":"James E. Clyburn",
+        "affil":"Democrat",
+        "state":"SC",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC06_2023.pdf"
+    },
+    {
+        "name":"Steve Cohen",
+        "affil":"Democrat",
+        "state":"TN",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN09_2023.pdf"
+    },
+    {
+        "name":"Tom Cole",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK04_2023.pdf"
+    },
+    {
+        "name":"Gerald E. Connolly",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA11_2023.pdf"
+    },
+    {
+        "name":"Jim Costa",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"21",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA21_2023.pdf"
+    },
+    {
+        "name":"Joe Courtney",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT02_2023.pdf"
+    },
+    {
+        "name":"Eric A. \"Rick\" Crawford",
+        "affil":"Republican",
+        "state":"AR",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AR01_2023.pdf"
+    },
+    {
+        "name":"Henry Cuellar",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"28",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX28_2023.pdf"
+    },
+    {
+        "name":"Danny K. Davis",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL07_2023.pdf"
+    },
+    {
+        "name":"Diana DeGette",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO01_2023.pdf"
+    },
+    {
+        "name":"Rosa L. DeLauro",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT03_2023.pdf"
+    },
+    {
+        "name":"Scott DesJarlais",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN04_2023.pdf"
+    },
+    {
+        "name":"Mario Diaz-Balart",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"26",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL26_2023.pdf"
+    },
+    {
+        "name":"Lloyd Doggett",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"37",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX37_2023.pdf"
+    },
+    {
+        "name":"Jeff Duncan",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC03_2023.pdf"
+    },
+    {
+        "name":"Anna G. Eshoo",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"16",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA16_2023.pdf"
+    },
+    {
+        "name":"Charles J. \"Chuck\" Fleischmann",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN03_2023.pdf"
+    },
+    {
+        "name":"Virginia Foxx",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC05_2023.pdf"
+    },
+    {
+        "name":"John Garamendi",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA08_2023.pdf"
+    },
+    {
+        "name":"Paul A. Gosar",
+        "affil":"Republican",
+        "state":"AZ",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ09_2023.pdf"
+    },
+    {
+        "name":"Kay Granger",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX12_2023.pdf"
+    },
+    {
+        "name":"Sam Graves",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO06_2023.pdf"
+    },
+    {
+        "name":"Al Green",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX09_2023.pdf"
+    },
+    {
+        "name":"H. Morgan Griffith",
+        "affil":"Republican",
+        "state":"VA",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA09_2023.pdf"
+    },
+    {
+        "name":"Ra\u00fal M. Grijalva",
+        "affil":"Democrat",
+        "state":"AZ",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ07_2023.pdf"
+    },
+    {
+        "name":"Brett Guthrie",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY02_2023.pdf"
+    },
+    {
+        "name":"Andy Harris",
+        "affil":"Republican",
+        "state":"MD",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD01_2023.pdf"
+    },
+    {
+        "name":"Brian Higgins",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"26",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY26_2023.pdf"
+    },
+    {
+        "name":"James A. Himes",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT04_2023.pdf"
+    },
+    {
+        "name":"Steny H. Hoyer",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD05_2023.pdf"
+    },
+    {
+        "name":"Bill Huizenga",
+        "affil":"Republican",
+        "state":"MI",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI04_2023.pdf"
+    },
+    {
+        "name":"Sheila Jackson Lee",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"18",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX18_2023.pdf"
+    },
+    {
+        "name":"Bill Johnson",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH06_2023.pdf"
+    },
+    {
+        "name":"Henry C. \"Hank\" Johnson, Jr.",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA04_2023.pdf"
+    },
+    {
+        "name":"Jim Jordan",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH04_2023.pdf"
+    },
+    {
+        "name":"Marcy Kaptur",
+        "affil":"Democrat",
+        "state":"OH",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH09_2023.pdf"
+    },
+    {
+        "name":"William R. Keating",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA09_2023.pdf"
+    },
+    {
+        "name":"Mike Kelly",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"16",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA16_2023.pdf"
+    },
+    {
+        "name":"Doug Lamborn",
+        "affil":"Republican",
+        "state":"CO",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO05_2023.pdf"
+    },
+    {
+        "name":"Rick Larsen",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA02_2023.pdf"
+    },
+    {
+        "name":"John B. Larson",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT01_2023.pdf"
+    },
+    {
+        "name":"Robert E. Latta",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH05_2023.pdf"
+    },
+    {
+        "name":"Barbara Lee",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA12_2023.pdf"
+    },
+    {
+        "name":"Zoe Lofgren",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"18",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA18_2023.pdf"
+    },
+    {
+        "name":"Frank D. Lucas",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK03_2023.pdf"
+    },
+    {
+        "name":"Blaine Luetkemeyer",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO03_2023.pdf"
+    },
+    {
+        "name":"Stephen F. Lynch",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA08_2023.pdf"
+    },
+    {
+        "name":"Doris O. Matsui",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA07_2023.pdf"
+    },
+    {
+        "name":"Kevin McCarthy",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"20",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA20_2023.pdf"
+    },
+    {
+        "name":"Michael T. McCaul",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX10_2023.pdf"
+    },
+    {
+        "name":"Tom McClintock",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA05_2023.pdf"
+    },
+    {
+        "name":"Betty McCollum",
+        "affil":"Democrat",
+        "state":"MN",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN04_2023.pdf"
+    },
+    {
+        "name":"James P. McGovern",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA02_2023.pdf"
+    },
+    {
+        "name":"Patrick T. McHenry",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC10_2023.pdf"
+    },
+    {
+        "name":"Cathy McMorris Rodgers",
+        "affil":"Republican",
+        "state":"WA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA05_2023.pdf"
+    },
+    {
+        "name":"Gregory W. Meeks",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY05_2023.pdf"
+    },
+    {
+        "name":"Gwen Moore",
+        "affil":"Democrat",
+        "state":"WI",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI04_2023.pdf"
+    },
+    {
+        "name":"Jerrold Nadler",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY12_2023.pdf"
+    },
+    {
+        "name":"Grace F. Napolitano",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"31",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA31_2023.pdf"
+    },
+    {
+        "name":"Richard E. Neal",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA01_2023.pdf"
+    },
+    {
+        "name":"Eleanor Holmes Norton",
+        "affil":"Democrat",
+        "state":"DC",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/DC00_2023.pdf"
+    },
+    {
+        "name":"Frank Pallone, Jr.",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ06_2023.pdf"
+    },
+    {
+        "name":"Bill Pascrell, Jr.",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ09_2023.pdf"
+    },
+    {
+        "name":"Nancy Pelosi",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA11_2023.pdf"
+    },
+    {
+        "name":"Chellie Pingree",
+        "affil":"Democrat",
+        "state":"ME",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ME01_2023.pdf"
+    },
+    {
+        "name":"Bill Posey",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL08_2023.pdf"
+    },
+    {
+        "name":"Mike Quigley",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL05_2023.pdf"
+    },
+    {
+        "name":"Harold Rogers",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY05_2023.pdf"
+    },
+    {
+        "name":"Mike Rogers",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL03_2023.pdf"
+    },
+    {
+        "name":"C. A. Dutch Ruppersberger",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD02_2023.pdf"
+    },
+    {
+        "name":"Gregorio Kilili Camacho Sablan",
+        "affil":"Democrat",
+        "state":"MP",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MP00_2023.pdf"
+    },
+    {
+        "name":"John P. Sarbanes",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD03_2023.pdf"
+    },
+    {
+        "name":"Steve Scalise",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA01_2023.pdf"
+    },
+    {
+        "name":"Janice D. Schakowsky",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL09_2023.pdf"
+    },
+    {
+        "name":"Adam B. Schiff",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"30",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA30_2023.pdf"
+    },
+    {
+        "name":"David Schweikert",
+        "affil":"Republican",
+        "state":"AZ",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ01_2023.pdf"
+    },
+    {
+        "name":"Austin Scott",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA08_2023.pdf"
+    },
+    {
+        "name":"David Scott",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA13_2023.pdf"
+    },
+    {
+        "name":"Robert C. \"Bobby\" Scott",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA03_2023.pdf"
+    },
+    {
+        "name":"Terri A. Sewell",
+        "affil":"Democrat",
+        "state":"AL",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL07_2023.pdf"
+    },
+    {
+        "name":"Brad Sherman",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"32",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA32_2023.pdf"
+    },
+    {
+        "name":"Michael K. Simpson",
+        "affil":"Republican",
+        "state":"ID",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ID02_2023.pdf"
+    },
+    {
+        "name":"Adam Smith",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA09_2023.pdf"
+    },
+    {
+        "name":"Adrian Smith",
+        "affil":"Republican",
+        "state":"NE",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NE03_2023.pdf"
+    },
+    {
+        "name":"Christopher H. Smith",
+        "affil":"Republican",
+        "state":"NJ",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ04_2023.pdf"
+    },
+    {
+        "name":"Linda T. S\u00e1nchez",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"38",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA38_2023.pdf"
+    },
+    {
+        "name":"Bennie G. Thompson",
+        "affil":"Democrat",
+        "state":"MS",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MS02_2023.pdf"
+    },
+    {
+        "name":"Mike Thompson",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA04_2023.pdf"
+    },
+    {
+        "name":"Glenn Thompson",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA15_2023.pdf"
+    },
+    {
+        "name":"Paul Tonko",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"20",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY20_2023.pdf"
+    },
+    {
+        "name":"Michael R. Turner",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH10_2023.pdf"
+    },
+    {
+        "name":"Nydia M. Vel\u00e1zquez",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY07_2023.pdf"
+    },
+    {
+        "name":"Tim Walberg",
+        "affil":"Republican",
+        "state":"MI",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI05_2023.pdf"
+    },
+    {
+        "name":"Debbie Wasserman Schultz",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"25",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL25_2023.pdf"
+    },
+    {
+        "name":"Maxine Waters",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"43",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA43_2023.pdf"
+    },
+    {
+        "name":"Daniel Webster",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL11_2023.pdf"
+    },
+    {
+        "name":"Joe Wilson",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC02_2023.pdf"
+    },
+    {
+        "name":"Frederica S. Wilson",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"24",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL24_2023.pdf"
+    },
+    {
+        "name":"Robert J. Wittman",
+        "affil":"Republican",
+        "state":"VA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA01_2023.pdf"
+    },
+    {
+        "name":"Steve Womack",
+        "affil":"Republican",
+        "state":"AR",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AR03_2023.pdf"
+    },
+    {
+        "name":"Mark E. Amodei",
+        "affil":"Republican",
+        "state":"NV",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NV02_2023.pdf"
+    },
+    {
+        "name":"Suzanne Bonamici",
+        "affil":"Democrat",
+        "state":"OR",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR01_2023.pdf"
+    },
+    {
+        "name":"Suzan K. DelBene",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA01_2023.pdf"
+    },
+    {
+        "name":"Thomas Massie",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY04_2023.pdf"
+    },
+    {
+        "name":"Donald M. Payne, Jr.",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ10_2023.pdf"
+    },
+    {
+        "name":"Bill Foster",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL11_2023.pdf"
+    },
+    {
+        "name":"Dina Titus",
+        "affil":"Democrat",
+        "state":"NV",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NV01_2023.pdf"
+    },
+    {
+        "name":"Doug LaMalfa",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA01_2023.pdf"
+    },
+    {
+        "name":"Jared Huffman",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA02_2023.pdf"
+    },
+    {
+        "name":"Ami Bera",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA06_2023.pdf"
+    },
+    {
+        "name":"Eric Swalwell",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA14_2023.pdf"
+    },
+    {
+        "name":"Julia Brownley",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"26",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA26_2023.pdf"
+    },
+    {
+        "name":"Tony C\u00e1rdenas",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"29",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA29_2023.pdf"
+    },
+    {
+        "name":"Raul Ruiz",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"25",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA25_2023.pdf"
+    },
+    {
+        "name":"Mark Takano",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"39",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA39_2023.pdf"
+    },
+    {
+        "name":"Juan Vargas",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"52",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA52_2023.pdf"
+    },
+    {
+        "name":"Scott H. Peters",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"50",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA50_2023.pdf"
+    },
+    {
+        "name":"Lois Frankel",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"22",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL22_2023.pdf"
+    },
+    {
+        "name":"Andy Barr",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY06_2023.pdf"
+    },
+    {
+        "name":"Daniel T. Kildee",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI08_2023.pdf"
+    },
+    {
+        "name":"Ann Wagner",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO02_2023.pdf"
+    },
+    {
+        "name":"Richard Hudson",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC09_2023.pdf"
+    },
+    {
+        "name":"Ann M. Kuster",
+        "affil":"Democrat",
+        "state":"NH",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NH02_2023.pdf"
+    },
+    {
+        "name":"Grace Meng",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY06_2023.pdf"
+    },
+    {
+        "name":"Hakeem S. Jeffries",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY08_2023.pdf"
+    },
+    {
+        "name":"Brad R. Wenstrup",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH02_2023.pdf"
+    },
+    {
+        "name":"Joyce Beatty",
+        "affil":"Democrat",
+        "state":"OH",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH03_2023.pdf"
+    },
+    {
+        "name":"David P. Joyce",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH14_2023.pdf"
+    },
+    {
+        "name":"Scott Perry",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA10_2023.pdf"
+    },
+    {
+        "name":"Matt Cartwright",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA08_2023.pdf"
+    },
+    {
+        "name":"Randy K. Weber, Sr.",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX14_2023.pdf"
+    },
+    {
+        "name":"Joaquin Castro",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"20",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX20_2023.pdf"
+    },
+    {
+        "name":"Roger Williams",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"25",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX25_2023.pdf"
+    },
+    {
+        "name":"Marc A. Veasey",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"33",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX33_2023.pdf"
+    },
+    {
+        "name":"Chris Stewart",
+        "affil":"Republican",
+        "state":"UT",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/UT02_2023.pdf"
+    },
+    {
+        "name":"Derek Kilmer",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA06_2023.pdf"
+    },
+    {
+        "name":"Mark Pocan",
+        "affil":"Democrat",
+        "state":"WI",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI02_2023.pdf"
+    },
+    {
+        "name":"Robin L. Kelly",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL02_2023.pdf"
+    },
+    {
+        "name":"Jason Smith",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO08_2023.pdf"
+    },
+    {
+        "name":"Katherine M. Clark",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA05_2023.pdf"
+    },
+    {
+        "name":"Donald Norcross",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ01_2023.pdf"
+    },
+    {
+        "name":"Alma S. Adams",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC12_2023.pdf"
+    },
+    {
+        "name":"Gary J. Palmer",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL06_2023.pdf"
+    },
+    {
+        "name":"J. French Hill",
+        "affil":"Republican",
+        "state":"AR",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AR02_2023.pdf"
+    },
+    {
+        "name":"Bruce Westerman",
+        "affil":"Republican",
+        "state":"AR",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AR04_2023.pdf"
+    },
+    {
+        "name":"Ruben Gallego",
+        "affil":"Democrat",
+        "state":"AZ",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ03_2023.pdf"
+    },
+    {
+        "name":"Mark DeSaulnier",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA10_2023.pdf"
+    },
+    {
+        "name":"Pete Aguilar",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"33",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA33_2023.pdf"
+    },
+    {
+        "name":"Ted Lieu",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"36",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA36_2023.pdf"
+    },
+    {
+        "name":"Norma J. Torres",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"35",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA35_2023.pdf"
+    },
+    {
+        "name":"Ken Buck",
+        "affil":"Republican",
+        "state":"CO",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO04_2023.pdf"
+    },
+    {
+        "name":"Earl L. \"Buddy\" Carter",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA01_2023.pdf"
+    },
+    {
+        "name":"Barry Loudermilk",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA11_2023.pdf"
+    },
+    {
+        "name":"Rick W. Allen",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA12_2023.pdf"
+    },
+    {
+        "name":"Mike Bost",
+        "affil":"Republican",
+        "state":"IL",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL12_2023.pdf"
+    },
+    {
+        "name":"Garret Graves",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA06_2023.pdf"
+    },
+    {
+        "name":"Seth Moulton",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA06_2023.pdf"
+    },
+    {
+        "name":"John R. Moolenaar",
+        "affil":"Republican",
+        "state":"MI",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI02_2023.pdf"
+    },
+    {
+        "name":"Debbie Dingell",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI06_2023.pdf"
+    },
+    {
+        "name":"Tom Emmer",
+        "affil":"Republican",
+        "state":"MN",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN06_2023.pdf"
+    },
+    {
+        "name":"David Rouzer",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC07_2023.pdf"
+    },
+    {
+        "name":"Bonnie Watson Coleman",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ12_2023.pdf"
+    },
+    {
+        "name":"Elise M. Stefanik",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"21",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY21_2023.pdf"
+    },
+    {
+        "name":"Brendan F. Boyle",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA02_2023.pdf"
+    },
+    {
+        "name":"Brian Babin",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"36",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX36_2023.pdf"
+    },
+    {
+        "name":"Donald S. Beyer, Jr.",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA08_2023.pdf"
+    },
+    {
+        "name":"Stacey E. Plaskett",
+        "affil":"Democrat",
+        "state":"VI",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VI00_2023.pdf"
+    },
+    {
+        "name":"Dan Newhouse",
+        "affil":"Republican",
+        "state":"WA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA04_2023.pdf"
+    },
+    {
+        "name":"Glenn Grothman",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI06_2023.pdf"
+    },
+    {
+        "name":"Alexander X. Mooney",
+        "affil":"Republican",
+        "state":"WV",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WV02_2023.pdf"
+    },
+    {
+        "name":"Aumua Amata Coleman Radewagen",
+        "affil":"Republican",
+        "state":"AS",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AS00_2023.pdf"
+    },
+    {
+        "name":"Trent Kelly",
+        "affil":"Republican",
+        "state":"MS",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MS01_2023.pdf"
+    },
+    {
+        "name":"Darin LaHood",
+        "affil":"Republican",
+        "state":"IL",
+        "district":"16",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL16_2023.pdf"
+    },
+    {
+        "name":"Warren Davidson",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH08_2023.pdf"
+    },
+    {
+        "name":"James Comer",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY01_2023.pdf"
+    },
+    {
+        "name":"Dwight Evans",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA03_2023.pdf"
+    },
+    {
+        "name":"Bradley Scott Schneider",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL10_2023.pdf"
+    },
+    {
+        "name":"Andy Biggs",
+        "affil":"Republican",
+        "state":"AZ",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ05_2023.pdf"
+    },
+    {
+        "name":"Ro Khanna",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"17",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA17_2023.pdf"
+    },
+    {
+        "name":"Jimmy Panetta",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"19",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA19_2023.pdf"
+    },
+    {
+        "name":"Salud O. Carbajal",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"24",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA24_2023.pdf"
+    },
+    {
+        "name":"Nanette Diaz Barrag\u00e1n",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"44",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA44_2023.pdf"
+    },
+    {
+        "name":"J. Luis Correa",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"46",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA46_2023.pdf"
+    },
+    {
+        "name":"Lisa Blunt Rochester",
+        "affil":"Democrat",
+        "state":"DE",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/DE00_2023.pdf"
+    },
+    {
+        "name":"Matt Gaetz",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL01_2023.pdf"
+    },
+    {
+        "name":"Neal P. Dunn",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL02_2023.pdf"
+    },
+    {
+        "name":"John H. Rutherford",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL05_2023.pdf"
+    },
+    {
+        "name":"Darren Soto",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL09_2023.pdf"
+    },
+    {
+        "name":"Brian J. Mast",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"21",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL21_2023.pdf"
+    },
+    {
+        "name":"A. Drew Ferguson IV",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA03_2023.pdf"
+    },
+    {
+        "name":"Raja Krishnamoorthi",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL08_2023.pdf"
+    },
+    {
+        "name":"Jim Banks",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN03_2023.pdf"
+    },
+    {
+        "name":"Clay Higgins",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA03_2023.pdf"
+    },
+    {
+        "name":"Mike Johnson",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA04_2023.pdf"
+    },
+    {
+        "name":"Jamie Raskin",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD08_2023.pdf"
+    },
+    {
+        "name":"Jack Bergman",
+        "affil":"Republican",
+        "state":"MI",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI01_2023.pdf"
+    },
+    {
+        "name":"Don Bacon",
+        "affil":"Republican",
+        "state":"NE",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NE02_2023.pdf"
+    },
+    {
+        "name":"Josh Gottheimer",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ05_2023.pdf"
+    },
+    {
+        "name":"Adriano Espaillat",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY13_2023.pdf"
+    },
+    {
+        "name":"Brian K. Fitzpatrick",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA01_2023.pdf"
+    },
+    {
+        "name":"Lloyd Smucker",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA11_2023.pdf"
+    },
+    {
+        "name":"Jenniffer Gonz\u00e1lez-Col\u00f3n",
+        "affil":"Republican",
+        "state":"PR",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PR00_2023.pdf"
+    },
+    {
+        "name":"David Kustoff",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN08_2023.pdf"
+    },
+    {
+        "name":"Vicente Gonzalez",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"34",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX34_2023.pdf"
+    },
+    {
+        "name":"Jodey C. Arrington",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"19",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX19_2023.pdf"
+    },
+    {
+        "name":"Pramila Jayapal",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA07_2023.pdf"
+    },
+    {
+        "name":"Mike Gallagher",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI08_2023.pdf"
+    },
+    {
+        "name":"Ron Estes",
+        "affil":"Republican",
+        "state":"KS",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KS04_2023.pdf"
+    },
+    {
+        "name":"Ralph Norman",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC05_2023.pdf"
+    },
+    {
+        "name":"Jimmy Gomez",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"34",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA34_2023.pdf"
+    },
+    {
+        "name":"John R. Curtis",
+        "affil":"Republican",
+        "state":"UT",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/UT03_2023.pdf"
+    },
+    {
+        "name":"Debbie Lesko",
+        "affil":"Republican",
+        "state":"AZ",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ08_2023.pdf"
+    },
+    {
+        "name":"Michael Cloud",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"27",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX27_2023.pdf"
+    },
+    {
+        "name":"Troy Balderson",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH12_2023.pdf"
+    },
+    {
+        "name":"Kevin Hern",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK01_2023.pdf"
+    },
+    {
+        "name":"Joseph D. Morelle",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"25",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY25_2023.pdf"
+    },
+    {
+        "name":"Mary Gay Scanlon",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA05_2023.pdf"
+    },
+    {
+        "name":"Susan Wild",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA07_2023.pdf"
+    },
+    {
+        "name":"Ed Case",
+        "affil":"Democrat",
+        "state":"HI",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/HI01_2023.pdf"
+    },
+    {
+        "name":"Steven Horsford",
+        "affil":"Democrat",
+        "state":"NV",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NV04_2023.pdf"
+    },
+    {
+        "name":"Greg Stanton",
+        "affil":"Democrat",
+        "state":"AZ",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ04_2023.pdf"
+    },
+    {
+        "name":"Josh Harder",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA09_2023.pdf"
+    },
+    {
+        "name":"Katie Porter",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"47",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA47_2023.pdf"
+    },
+    {
+        "name":"Mike Levin",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"49",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA49_2023.pdf"
+    },
+    {
+        "name":"Joe Neguse",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO02_2023.pdf"
+    },
+    {
+        "name":"Jason Crow",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO06_2023.pdf"
+    },
+    {
+        "name":"Jahana Hayes",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT05_2023.pdf"
+    },
+    {
+        "name":"Michael Waltz",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL06_2023.pdf"
+    },
+    {
+        "name":"W. Gregory Steube",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"17",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL17_2023.pdf"
+    },
+    {
+        "name":"Lucy McBath",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA07_2023.pdf"
+    },
+    {
+        "name":"Russ Fulcher",
+        "affil":"Republican",
+        "state":"ID",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ID01_2023.pdf"
+    },
+    {
+        "name":"Jes\u00fas G. \"Chuy\" Garc\u00eda",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL04_2023.pdf"
+    },
+    {
+        "name":"Sean Casten",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL06_2023.pdf"
+    },
+    {
+        "name":"Lauren Underwood",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL14_2023.pdf"
+    },
+    {
+        "name":"James R. Baird",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN04_2023.pdf"
+    },
+    {
+        "name":"Greg Pence",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN06_2023.pdf"
+    },
+    {
+        "name":"Sharice Davids",
+        "affil":"Democrat",
+        "state":"KS",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KS03_2023.pdf"
+    },
+    {
+        "name":"Lori Trahan",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA03_2023.pdf"
+    },
+    {
+        "name":"Ayanna Pressley",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA07_2023.pdf"
+    },
+    {
+        "name":"David J. Trone",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD06_2023.pdf"
+    },
+    {
+        "name":"Elissa Slotkin",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI07_2023.pdf"
+    },
+    {
+        "name":"Haley M. Stevens",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI11_2023.pdf"
+    },
+    {
+        "name":"Rashida Tlaib",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI12_2023.pdf"
+    },
+    {
+        "name":"Angie Craig",
+        "affil":"Democrat",
+        "state":"MN",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN02_2023.pdf"
+    },
+    {
+        "name":"Dean Phillips",
+        "affil":"Democrat",
+        "state":"MN",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN03_2023.pdf"
+    },
+    {
+        "name":"Ilhan Omar",
+        "affil":"Democrat",
+        "state":"MN",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN05_2023.pdf"
+    },
+    {
+        "name":"Pete Stauber",
+        "affil":"Republican",
+        "state":"MN",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN08_2023.pdf"
+    },
+    {
+        "name":"Michael Guest",
+        "affil":"Republican",
+        "state":"MS",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MS03_2023.pdf"
+    },
+    {
+        "name":"Kelly Armstrong",
+        "affil":"Republican",
+        "state":"ND",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ND00_2023.pdf"
+    },
+    {
+        "name":"Chris Pappas",
+        "affil":"Democrat",
+        "state":"NH",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NH01_2023.pdf"
+    },
+    {
+        "name":"Jefferson Van Drew",
+        "affil":"Republican",
+        "state":"NJ",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ02_2023.pdf"
+    },
+    {
+        "name":"Andy Kim",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ03_2023.pdf"
+    },
+    {
+        "name":"Mikie Sherrill",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ11_2023.pdf"
+    },
+    {
+        "name":"Susie Lee",
+        "affil":"Democrat",
+        "state":"NV",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NV03_2023.pdf"
+    },
+    {
+        "name":"Alexandria Ocasio-Cortez",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY14_2023.pdf"
+    },
+    {
+        "name":"Madeleine Dean",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA04_2023.pdf"
+    },
+    {
+        "name":"Chrissy Houlahan",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA06_2023.pdf"
+    },
+    {
+        "name":"Daniel Meuser",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA09_2023.pdf"
+    },
+    {
+        "name":"John Joyce",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA13_2023.pdf"
+    },
+    {
+        "name":"Guy Reschenthaler",
+        "affil":"Republican",
+        "state":"PA",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA14_2023.pdf"
+    },
+    {
+        "name":"William R. Timmons IV",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC04_2023.pdf"
+    },
+    {
+        "name":"Dusty Johnson",
+        "affil":"Republican",
+        "state":"SD",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SD00_2023.pdf"
+    },
+    {
+        "name":"Tim Burchett",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN02_2023.pdf"
+    },
+    {
+        "name":"John W. Rose",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN06_2023.pdf"
+    },
+    {
+        "name":"Mark E. Green",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN07_2023.pdf"
+    },
+    {
+        "name":"Dan Crenshaw",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX02_2023.pdf"
+    },
+    {
+        "name":"Lance Gooden",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX05_2023.pdf"
+    },
+    {
+        "name":"Lizzie Fletcher",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX07_2023.pdf"
+    },
+    {
+        "name":"Veronica Escobar",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"16",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX16_2023.pdf"
+    },
+    {
+        "name":"Chip Roy",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"21",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX21_2023.pdf"
+    },
+    {
+        "name":"Sylvia R. Garcia",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"29",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX29_2023.pdf"
+    },
+    {
+        "name":"Colin Z. Allred",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"32",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX32_2023.pdf"
+    },
+    {
+        "name":"Ben Cline",
+        "affil":"Republican",
+        "state":"VA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA06_2023.pdf"
+    },
+    {
+        "name":"Abigail Davis Spanberger",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA07_2023.pdf"
+    },
+    {
+        "name":"Jennifer Wexton",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA10_2023.pdf"
+    },
+    {
+        "name":"Kim Schrier",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA08_2023.pdf"
+    },
+    {
+        "name":"Bryan Steil",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI01_2023.pdf"
+    },
+    {
+        "name":"Carol D. Miller",
+        "affil":"Republican",
+        "state":"WV",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WV01_2023.pdf"
+    },
+    {
+        "name":"Jared F. Golden",
+        "affil":"Democrat",
+        "state":"ME",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ME02_2023.pdf"
+    },
+    {
+        "name":"Dan Bishop",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC08_2023.pdf"
+    },
+    {
+        "name":"Gregory F. Murphy",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC03_2023.pdf"
+    },
+    {
+        "name":"Kweisi Mfume",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD07_2023.pdf"
+    },
+    {
+        "name":"Thomas P. Tiffany",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI07_2023.pdf"
+    },
+    {
+        "name":"Mike Garcia",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"27",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA27_2023.pdf"
+    },
+    {
+        "name":"Darrell Issa",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"48",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA48_2023.pdf"
+    },
+    {
+        "name":"Pete Sessions",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"17",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX17_2023.pdf"
+    },
+    {
+        "name":"David G. Valadao",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"22",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA22_2023.pdf"
+    },
+    {
+        "name":"Jerry L. Carl",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL01_2023.pdf"
+    },
+    {
+        "name":"Barry Moore",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL02_2023.pdf"
+    },
+    {
+        "name":"Jay Obernolte",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"23",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA23_2023.pdf"
+    },
+    {
+        "name":"Young Kim",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"40",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA40_2023.pdf"
+    },
+    {
+        "name":"Michelle Steel",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"45",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA45_2023.pdf"
+    },
+    {
+        "name":"Sara Jacobs",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"51",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA51_2023.pdf"
+    },
+    {
+        "name":"Lauren Boebert",
+        "affil":"Republican",
+        "state":"CO",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO03_2023.pdf"
+    },
+    {
+        "name":"Kat Cammack",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL03_2023.pdf"
+    },
+    {
+        "name":"C. Scott Franklin",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"18",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL18_2023.pdf"
+    },
+    {
+        "name":"Byron Donalds",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"19",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL19_2023.pdf"
+    },
+    {
+        "name":"Carlos A. Gimenez",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"28",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL28_2023.pdf"
+    },
+    {
+        "name":"Maria Elvira Salazar",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"27",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL27_2023.pdf"
+    },
+    {
+        "name":"Nikema Williams",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA05_2023.pdf"
+    },
+    {
+        "name":"Andrew S. Clyde",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA09_2023.pdf"
+    },
+    {
+        "name":"Marjorie Taylor Greene",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA14_2023.pdf"
+    },
+    {
+        "name":"Ashley Hinson",
+        "affil":"Republican",
+        "state":"IA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IA02_2023.pdf"
+    },
+    {
+        "name":"Mariannette Miller-Meeks",
+        "affil":"Republican",
+        "state":"IA",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IA01_2023.pdf"
+    },
+    {
+        "name":"Randy Feenstra",
+        "affil":"Republican",
+        "state":"IA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IA04_2023.pdf"
+    },
+    {
+        "name":"Mary E. Miller",
+        "affil":"Republican",
+        "state":"IL",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL15_2023.pdf"
+    },
+    {
+        "name":"Frank J. Mrvan",
+        "affil":"Democrat",
+        "state":"IN",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN01_2023.pdf"
+    },
+    {
+        "name":"Victoria Spartz",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN05_2023.pdf"
+    },
+    {
+        "name":"Tracey Mann",
+        "affil":"Republican",
+        "state":"KS",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KS01_2023.pdf"
+    },
+    {
+        "name":"Jake LaTurner",
+        "affil":"Republican",
+        "state":"KS",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KS02_2023.pdf"
+    },
+    {
+        "name":"Jake Auchincloss",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA04_2023.pdf"
+    },
+    {
+        "name":"Lisa C. McClain",
+        "affil":"Republican",
+        "state":"MI",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI09_2023.pdf"
+    },
+    {
+        "name":"Michelle Fischbach",
+        "affil":"Republican",
+        "state":"MN",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN07_2023.pdf"
+    },
+    {
+        "name":"Cori Bush",
+        "affil":"Democrat",
+        "state":"MO",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO01_2023.pdf"
+    },
+    {
+        "name":"Matthew M. Rosendale, Sr.",
+        "affil":"Republican",
+        "state":"MT",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MT02_2023.pdf"
+    },
+    {
+        "name":"Deborah K. Ross",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC02_2023.pdf"
+    },
+    {
+        "name":"Kathy E. Manning",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC06_2023.pdf"
+    },
+    {
+        "name":"Teresa Leger Fernandez",
+        "affil":"Democrat",
+        "state":"NM",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NM03_2023.pdf"
+    },
+    {
+        "name":"Andrew R. Garbarino",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY02_2023.pdf"
+    },
+    {
+        "name":"Nicole Malliotakis",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY11_2023.pdf"
+    },
+    {
+        "name":"Ritchie Torres",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY15_2023.pdf"
+    },
+    {
+        "name":"Jamaal Bowman",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"16",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY16_2023.pdf"
+    },
+    {
+        "name":"Stephanie I. Bice",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK05_2023.pdf"
+    },
+    {
+        "name":"Cliff Bentz",
+        "affil":"Republican",
+        "state":"OR",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR02_2023.pdf"
+    },
+    {
+        "name":"Nancy Mace",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC01_2023.pdf"
+    },
+    {
+        "name":"Diana Harshbarger",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN01_2023.pdf"
+    },
+    {
+        "name":"Pat Fallon",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX04_2023.pdf"
+    },
+    {
+        "name":"August Pfluger",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX11_2023.pdf"
+    },
+    {
+        "name":"Ronny Jackson",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX13_2023.pdf"
+    },
+    {
+        "name":"Troy E. Nehls",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"22",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX22_2023.pdf"
+    },
+    {
+        "name":"Tony Gonzales",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"23",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX23_2023.pdf"
+    },
+    {
+        "name":"Beth Van Duyne",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"24",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX24_2023.pdf"
+    },
+    {
+        "name":"Blake D. Moore",
+        "affil":"Republican",
+        "state":"UT",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/UT01_2023.pdf"
+    },
+    {
+        "name":"Burgess Owens",
+        "affil":"Republican",
+        "state":"UT",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/UT04_2023.pdf"
+    },
+    {
+        "name":"Bob Good",
+        "affil":"Republican",
+        "state":"VA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA05_2023.pdf"
+    },
+    {
+        "name":"Marilyn Strickland",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA10_2023.pdf"
+    },
+    {
+        "name":"Scott Fitzgerald",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI05_2023.pdf"
+    },
+    {
+        "name":"Claudia Tenney",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"24",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY24_2023.pdf"
+    },
+    {
+        "name":"Julia Letlow",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA05_2023.pdf"
+    },
+    {
+        "name":"Troy A. Carter",
+        "affil":"Democrat",
+        "state":"LA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA02_2023.pdf"
+    },
+    {
+        "name":"Melanie A. Stansbury",
+        "affil":"Democrat",
+        "state":"NM",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NM01_2023.pdf"
+    },
+    {
+        "name":"Jake Ellzey",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX06_2023.pdf"
+    },
+    {
+        "name":"Shontel M. Brown",
+        "affil":"Democrat",
+        "state":"OH",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH11_2023.pdf"
+    },
+    {
+        "name":"Mike Carey",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH15_2023.pdf"
+    },
+    {
+        "name":"Sheila Cherfilus-McCormick",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"20",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL20_2023.pdf"
+    },
+    {
+        "name":"Mike Flood",
+        "affil":"Republican",
+        "state":"NE",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NE01_2023.pdf"
+    },
+    {
+        "name":"Brad Finstad",
+        "affil":"Republican",
+        "state":"MN",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN01_2023.pdf"
+    },
+    {
+        "name":"Mary Sattler Peltola",
+        "affil":"Democrat",
+        "state":"AK",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AK00_2023.pdf"
+    },
+    {
+        "name":"Patrick Ryan",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"18",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY18_2023.pdf"
+    },
+    {
+        "name":"Rudy Yakym III",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN02_2023.pdf"
+    },
+    {
+        "name":"Ryan K. Zinke",
+        "affil":"Republican",
+        "state":"MT",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MT01_2023.pdf"
+    },
+    {
+        "name":"Dale W. Strong",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL05_2023.pdf"
+    },
+    {
+        "name":"Elijah Crane",
+        "affil":"Republican",
+        "state":"AZ",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ02_2023.pdf"
+    },
+    {
+        "name":"Juan Ciscomani",
+        "affil":"Republican",
+        "state":"AZ",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ06_2023.pdf"
+    },
+    {
+        "name":"Kevin Kiley",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA03_2023.pdf"
+    },
+    {
+        "name":"John S. Duarte",
+        "affil":"Republican",
+        "state":"CA",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA13_2023.pdf"
+    },
+    {
+        "name":"Kevin Mullin",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA15_2023.pdf"
+    },
+    {
+        "name":"Sydney Kamlager-Dove",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"37",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA37_2023.pdf"
+    },
+    {
+        "name":"Robert Garcia",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"42",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA42_2023.pdf"
+    },
+    {
+        "name":"Brittany Pettersen",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO07_2023.pdf"
+    },
+    {
+        "name":"Yadira Caraveo",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO08_2023.pdf"
+    },
+    {
+        "name":"Aaron Bean",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL04_2023.pdf"
+    },
+    {
+        "name":"Cory Mills",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL07_2023.pdf"
+    },
+    {
+        "name":"Maxwell Frost",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL10_2023.pdf"
+    },
+    {
+        "name":"Anna Paulina Luna",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL13_2023.pdf"
+    },
+    {
+        "name":"Laurel M. Lee",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL15_2023.pdf"
+    },
+    {
+        "name":"Jared Moskowitz",
+        "affil":"Democrat",
+        "state":"FL",
+        "district":"23",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL23_2023.pdf"
+    },
+    {
+        "name":"Richard McCormick",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA06_2023.pdf"
+    },
+    {
+        "name":"Mike Collins",
+        "affil":"Republican",
+        "state":"GA",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA10_2023.pdf"
+    },
+    {
+        "name":"James C. Moylan",
+        "affil":"Republican",
+        "state":"GU",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GU00_2023.pdf"
+    },
+    {
+        "name":"Jill N. Tokuda",
+        "affil":"Democrat",
+        "state":"HI",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/HI02_2023.pdf"
+    },
+    {
+        "name":"Zachary Nunn",
+        "affil":"Republican",
+        "state":"IA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IA03_2023.pdf"
+    },
+    {
+        "name":"Jonathan L. Jackson",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL01_2023.pdf"
+    },
+    {
+        "name":"Delia C. Ramirez",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL03_2023.pdf"
+    },
+    {
+        "name":"Nikki Budzinski",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL13_2023.pdf"
+    },
+    {
+        "name":"Eric Sorensen",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"17",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL17_2023.pdf"
+    },
+    {
+        "name":"Erin Houchin",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"09",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN09_2023.pdf"
+    },
+    {
+        "name":"Morgan McGarvey",
+        "affil":"Democrat",
+        "state":"KY",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY03_2023.pdf"
+    },
+    {
+        "name":"Glenn Ivey",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD04_2023.pdf"
+    },
+    {
+        "name":"Hillary J. Scholten",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI03_2023.pdf"
+    },
+    {
+        "name":"John James",
+        "affil":"Republican",
+        "state":"MI",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI10_2023.pdf"
+    },
+    {
+        "name":"Shri Thanedar",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI13_2023.pdf"
+    },
+    {
+        "name":"Mark Alford",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO04_2023.pdf"
+    },
+    {
+        "name":"Eric Burlison",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO07_2023.pdf"
+    },
+    {
+        "name":"Mike Ezell",
+        "affil":"Republican",
+        "state":"MS",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MS04_2023.pdf"
+    },
+    {
+        "name":"Donald G. Davis",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC01_2023.pdf"
+    },
+    {
+        "name":"Valerie P. Foushee",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC04_2023.pdf"
+    },
+    {
+        "name":"Chuck Edwards",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"11",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC11_2023.pdf"
+    },
+    {
+        "name":"Wiley Nickel",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC13_2023.pdf"
+    },
+    {
+        "name":"Jeff Jackson",
+        "affil":"Democrat",
+        "state":"NC",
+        "district":"14",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC14_2023.pdf"
+    },
+    {
+        "name":"Thomas H. Kean, Jr.",
+        "affil":"Republican",
+        "state":"NJ",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ07_2023.pdf"
+    },
+    {
+        "name":"Robert Menendez",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ08_2023.pdf"
+    },
+    {
+        "name":"Gabe Vasquez",
+        "affil":"Democrat",
+        "state":"NM",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NM02_2023.pdf"
+    },
+    {
+        "name":"Nick LaLota",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY01_2023.pdf"
+    },
+    {
+        "name":"George Santos",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY03_2023.pdf"
+    },
+    {
+        "name":"Anthony D\u2019Esposito",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY04_2023.pdf"
+    },
+    {
+        "name":"Daniel S. Goldman",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"10",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY10_2023.pdf"
+    },
+    {
+        "name":"Michael Lawler",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"17",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY17_2023.pdf"
+    },
+    {
+        "name":"Marcus J. Molinaro",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"19",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY19_2023.pdf"
+    },
+    {
+        "name":"Brandon Williams",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"22",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY22_2023.pdf"
+    },
+    {
+        "name":"Nicholas A. Langworthy",
+        "affil":"Republican",
+        "state":"NY",
+        "district":"23",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY23_2023.pdf"
+    },
+    {
+        "name":"Greg Landsman",
+        "affil":"Democrat",
+        "state":"OH",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH01_2023.pdf"
+    },
+    {
+        "name":"Max L. Miller",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH07_2023.pdf"
+    },
+    {
+        "name":"Emilia Strong Sykes",
+        "affil":"Democrat",
+        "state":"OH",
+        "district":"13",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH13_2023.pdf"
+    },
+    {
+        "name":"Josh Brecheen",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK02_2023.pdf"
+    },
+    {
+        "name":"Val T. Hoyle",
+        "affil":"Democrat",
+        "state":"OR",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR04_2023.pdf"
+    },
+    {
+        "name":"Lori Chavez-DeRemer",
+        "affil":"Republican",
+        "state":"OR",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR05_2023.pdf"
+    },
+    {
+        "name":"Andrea Salinas",
+        "affil":"Democrat",
+        "state":"OR",
+        "district":"06",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR06_2023.pdf"
+    },
+    {
+        "name":"Summer L. Lee",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"12",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA12_2023.pdf"
+    },
+    {
+        "name":"Christopher R. Deluzio",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"17",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA17_2023.pdf"
+    },
+    {
+        "name":"Seth Magaziner",
+        "affil":"Democrat",
+        "state":"RI",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/RI02_2023.pdf"
+    },
+    {
+        "name":"Russell Fry",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"07",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC07_2023.pdf"
+    },
+    {
+        "name":"Andrew Ogles",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"05",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN05_2023.pdf"
+    },
+    {
+        "name":"Nathaniel Moran",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"01",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX01_2023.pdf"
+    },
+    {
+        "name":"Keith Self",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX03_2023.pdf"
+    },
+    {
+        "name":"Morgan Luttrell",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"08",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX08_2023.pdf"
+    },
+    {
+        "name":"Monica De La Cruz",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"15",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX15_2023.pdf"
+    },
+    {
+        "name":"Jasmine Crockett",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"30",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX30_2023.pdf"
+    },
+    {
+        "name":"Greg Casar",
+        "affil":"Democrat",
+        "state":"TX",
+        "district":"35",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX35_2023.pdf"
+    },
+    {
+        "name":"Wesley Hunt",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"38",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX38_2023.pdf"
+    },
+    {
+        "name":"Jennifer Kiggans",
+        "affil":"Republican",
+        "state":"VA",
+        "district":"02",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA02_2023.pdf"
+    },
+    {
+        "name":"Becca Balint",
+        "affil":"Democrat",
+        "state":"VT",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VT00_2023.pdf"
+    },
+    {
+        "name":"Marie Gluesenkamp Perez",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA03_2023.pdf"
+    },
+    {
+        "name":"Derrick Van Orden",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"03",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI03_2023.pdf"
+    },
+    {
+        "name":"Harriet M. Hageman",
+        "affil":"Republican",
+        "state":"WY",
+        "district":"00",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WY00_2023.pdf"
+    },
+    {
+        "name":"Jennifer L. McClellan",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"04",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA04_2023.pdf"
+    }
 ]

--- a/src/helpers/senate.js
+++ b/src/helpers/senate.js
@@ -1,703 +1,702 @@
-﻿export const Senate = 
 [
-  {
-    "name": "Sherrod Brown",
-    "affil": "Democrat",
-    "state": "OH",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH_2021.pdf"
-  },
-  {
-    "name": "Maria Cantwell",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA_2021.pdf"
-  },
-  {
-    "name": "Benjamin L. Cardin",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD_2021.pdf"
-  },
-  {
-    "name": "Thomas R. Carper",
-    "affil": "Democrat",
-    "state": "DE",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/DE_2021.pdf"
-  },
-  {
-    "name": "Robert P. Casey, Jr.",
-    "affil": "Democrat",
-    "state": "PA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA_2021.pdf"
-  },
-  {
-    "name": "Dianne Feinstein",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA_2021.pdf"
-  },
-  {
-    "name": "Amy Klobuchar",
-    "affil": "Democrat",
-    "state": "MN",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN_2021.pdf"
-  },
-  {
-    "name": "Robert Menendez",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ_2021.pdf"
-  },
-  {
-    "name": "Bernard Sanders",
-    "affil": "Independent",
-    "state": "VT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VT_2021.pdf"
-  },
-  {
-    "name": "Debbie Stabenow",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI_2021.pdf"
-  },
-  {
-    "name": "Jon Tester",
-    "affil": "Democrat",
-    "state": "MT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MT_2021.pdf"
-  },
-  {
-    "name": "Sheldon Whitehouse",
-    "affil": "Democrat",
-    "state": "RI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/RI_2021.pdf"
-  },
-  {
-    "name": "John Barrasso",
-    "affil": "Republican",
-    "state": "WY",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WY_2021.pdf"
-  },
-  {
-    "name": "Roger F. Wicker",
-    "affil": "Republican",
-    "state": "MS",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MS_2021.pdf"
-  },
-  {
-    "name": "Susan M. Collins",
-    "affil": "Republican",
-    "state": "ME",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ME_2021.pdf"
-  },
-  {
-    "name": "John Cornyn",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX_2021.pdf"
-  },
-  {
-    "name": "Richard J. Durbin",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL_2021.pdf"
-  },
-  {
-    "name": "Lindsey Graham",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC_2021.pdf"
-  },
-  {
-    "name": "James M. Inhofe",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK_2021.pdf"
-  },
-  {
-    "name": "Mitch McConnell",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY_2021.pdf"
-  },
-  {
-    "name": "Jeff Merkley",
-    "affil": "Democrat",
-    "state": "OR",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR_2021.pdf"
-  },
-  {
-    "name": "Jack Reed",
-    "affil": "Democrat",
-    "state": "RI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/RI_2021.pdf"
-  },
-  {
-    "name": "James E. Risch",
-    "affil": "Republican",
-    "state": "ID",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ID_2021.pdf"
-  },
-  {
-    "name": "Jeanne Shaheen",
-    "affil": "Democrat",
-    "state": "NH",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NH_2021.pdf"
-  },
-  {
-    "name": "Mark R. Warner",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA_2021.pdf"
-  },
-  {
-    "name": "Kirsten E. Gillibrand",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY_2021.pdf"
-  },
-  {
-    "name": "Christopher A. Coons",
-    "affil": "Democrat",
-    "state": "DE",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/DE_2021.pdf"
-  },
-  {
-    "name": "Joe Manchin, III",
-    "affil": "Democrat",
-    "state": "WV",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WV_2021.pdf"
-  },
-  {
-    "name": "Tammy Baldwin",
-    "affil": "Democrat",
-    "state": "WI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI_2021.pdf"
-  },
-  {
-    "name": "Michael F. Bennet",
-    "affil": "Democrat",
-    "state": "CO",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO_2021.pdf"
-  },
-  {
-    "name": "Marsha Blackburn",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN_2021.pdf"
-  },
-  {
-    "name": "Richard Blumenthal",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT_2021.pdf"
-  },
-  {
-    "name": "Roy Blunt",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO_2021.pdf"
-  },
-  {
-    "name": "John Boozman",
-    "affil": "Republican",
-    "state": "AR",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AR_2021.pdf"
-  },
-  {
-    "name": "Richard Burr",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC_2021.pdf"
-  },
-  {
-    "name": "Shelley Moore Capito",
-    "affil": "Republican",
-    "state": "WV",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WV_2021.pdf"
-  },
-  {
-    "name": "Bill Cassidy",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA_2021.pdf"
-  },
-  {
-    "name": "Mike Crapo",
-    "affil": "Republican",
-    "state": "ID",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ID_2021.pdf"
-  },
-  {
-    "name": "Chuck Grassley",
-    "affil": "Republican",
-    "state": "IA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IA_2021.pdf"
-  },
-  {
-    "name": "Martin Heinrich",
-    "affil": "Democrat",
-    "state": "NM",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NM_2021.pdf"
-  },
-  {
-    "name": "Mazie K. Hirono",
-    "affil": "Democrat",
-    "state": "HI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/HI_2021.pdf"
-  },
-  {
-    "name": "John Hoeven",
-    "affil": "Republican",
-    "state": "ND",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ND_2021.pdf"
-  },
-  {
-    "name": "Ron Johnson",
-    "affil": "Republican",
-    "state": "WI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WI_2021.pdf"
-  },
-  {
-    "name": "James Lankford",
-    "affil": "Republican",
-    "state": "OK",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OK_2021.pdf"
-  },
-  {
-    "name": "Patrick J. Leahy",
-    "affil": "Democrat",
-    "state": "VT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VT_2021.pdf"
-  },
-  {
-    "name": "Mike Lee",
-    "affil": "Republican",
-    "state": "UT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/UT_2021.pdf"
-  },
-  {
-    "name": "Ben Ray Luján",
-    "affil": "Democrat",
-    "state": "NM",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NM_2021.pdf"
-  },
-  {
-    "name": "Edward J. Markey",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA_2021.pdf"
-  },
-  {
-    "name": "Jerry Moran",
-    "affil": "Republican",
-    "state": "KS",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KS_2021.pdf"
-  },
-  {
-    "name": "Lisa Murkowski",
-    "affil": "Republican",
-    "state": "AK",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AK_2021.pdf"
-  },
-  {
-    "name": "Christopher Murphy",
-    "affil": "Democrat",
-    "state": "CT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CT_2021.pdf"
-  },
-  {
-    "name": "Patty Murray",
-    "affil": "Democrat",
-    "state": "WA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WA_2021.pdf"
-  },
-  {
-    "name": "Rand Paul",
-    "affil": "Republican",
-    "state": "KY",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KY_2021.pdf"
-  },
-  {
-    "name": "Gary C. Peters",
-    "affil": "Democrat",
-    "state": "MI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MI_2021.pdf"
-  },
-  {
-    "name": "Rob Portman",
-    "affil": "Republican",
-    "state": "OH",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OH_2021.pdf"
-  },
-  {
-    "name": "Marco Rubio",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL_2021.pdf"
-  },
-  {
-    "name": "Charles E. Schumer",
-    "affil": "Democrat",
-    "state": "NY",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NY_2021.pdf"
-  },
-  {
-    "name": "Tim Scott",
-    "affil": "Republican",
-    "state": "SC",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SC_2021.pdf"
-  },
-  {
-    "name": "Richard C. Shelby",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL_2021.pdf"
-  },
-  {
-    "name": "John Thune",
-    "affil": "Republican",
-    "state": "SD",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SD_2021.pdf"
-  },
-  {
-    "name": "Patrick J. Toomey",
-    "affil": "Republican",
-    "state": "PA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/PA_2021.pdf"
-  },
-  {
-    "name": "Chris Van Hollen",
-    "affil": "Democrat",
-    "state": "MD",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MD_2021.pdf"
-  },
-  {
-    "name": "Ron Wyden",
-    "affil": "Democrat",
-    "state": "OR",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/OR_2021.pdf"
-  },
-  {
-    "name": "Todd Young",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN_2021.pdf"
-  },
-  {
-    "name": "Brian Schatz",
-    "affil": "Democrat",
-    "state": "HI",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/HI_2021.pdf"
-  },
-  {
-    "name": "Tom Cotton",
-    "affil": "Republican",
-    "state": "AR",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AR_2021.pdf"
-  },
-  {
-    "name": "Kyrsten Sinema",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ_2021.pdf"
-  },
-  {
-    "name": "Tammy Duckworth",
-    "affil": "Democrat",
-    "state": "IL",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IL_2021.pdf"
-  },
-  {
-    "name": "Elizabeth Warren",
-    "affil": "Democrat",
-    "state": "MA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MA_2021.pdf"
-  },
-  {
-    "name": "Angus S. King, Jr.",
-    "affil": "Independent",
-    "state": "ME",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ME_2021.pdf"
-  },
-  {
-    "name": "Steve Daines",
-    "affil": "Republican",
-    "state": "MT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MT_2021.pdf"
-  },
-  {
-    "name": "Kevin Cramer",
-    "affil": "Republican",
-    "state": "ND",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/ND_2021.pdf"
-  },
-  {
-    "name": "Deb Fischer",
-    "affil": "Republican",
-    "state": "NE",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NE_2021.pdf"
-  },
-  {
-    "name": "Ted Cruz",
-    "affil": "Republican",
-    "state": "TX",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TX_2021.pdf"
-  },
-  {
-    "name": "Tim Kaine",
-    "affil": "Democrat",
-    "state": "VA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/VA_2021.pdf"
-  },
-  {
-    "name": "Cory A. Booker",
-    "affil": "Democrat",
-    "state": "NJ",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NJ_2021.pdf"
-  },
-  {
-    "name": "Dan Sullivan",
-    "affil": "Republican",
-    "state": "AK",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AK_2021.pdf"
-  },
-  {
-    "name": "Joni Ernst",
-    "affil": "Republican",
-    "state": "IA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IA_2021.pdf"
-  },
-  {
-    "name": "Thom Tillis",
-    "affil": "Republican",
-    "state": "NC",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NC_2021.pdf"
-  },
-  {
-    "name": "Mike Rounds",
-    "affil": "Republican",
-    "state": "SD",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/SD_2021.pdf"
-  },
-  {
-    "name": "Ben Sasse",
-    "affil": "Republican",
-    "state": "NE",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NE_2021.pdf"
-  },
-  {
-    "name": "John Kennedy",
-    "affil": "Republican",
-    "state": "LA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/LA_2021.pdf"
-  },
-  {
-    "name": "Margaret Wood Hassan",
-    "affil": "Democrat",
-    "state": "NH",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NH_2021.pdf"
-  },
-  {
-    "name": "Catherine Cortez Masto",
-    "affil": "Democrat",
-    "state": "NV",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NV_2021.pdf"
-  },
-  {
-    "name": "Roger Marshall",
-    "affil": "Republican",
-    "state": "KS",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/KS_2021.pdf"
-  },
-  {
-    "name": "Jacky Rosen",
-    "affil": "Democrat",
-    "state": "NV",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/NV_2021.pdf"
-  },
-  {
-    "name": "Tina Smith",
-    "affil": "Democrat",
-    "state": "MN",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MN_2021.pdf"
-  },
-  {
-    "name": "Cindy Hyde-Smith",
-    "affil": "Republican",
-    "state": "MS",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MS_2021.pdf"
-  },
-  {
-    "name": "Rick Scott",
-    "affil": "Republican",
-    "state": "FL",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/FL_2021.pdf"
-  },
-  {
-    "name": "Mike Braun",
-    "affil": "Republican",
-    "state": "IN",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/IN_2021.pdf"
-  },
-  {
-    "name": "Josh Hawley",
-    "affil": "Republican",
-    "state": "MO",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/MO_2021.pdf"
-  },
-  {
-    "name": "Mitt Romney",
-    "affil": "Republican",
-    "state": "UT",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/UT_2021.pdf"
-  },
-  {
-    "name": "Mark Kelly",
-    "affil": "Democrat",
-    "state": "AZ",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AZ_2021.pdf"
-  },
-  {
-    "name": "Cynthia M. Lummis",
-    "affil": "Republican",
-    "state": "WY",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/WY_2021.pdf"
-  },
-  {
-    "name": "Tommy Tuberville",
-    "affil": "Republican",
-    "state": "AL",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/AL_2021.pdf"
-  },
-  {
-    "name": "John W. Hickenlooper",
-    "affil": "Democrat",
-    "state": "CO",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CO_2021.pdf"
-  },
-  {
-    "name": "Bill Hagerty",
-    "affil": "Republican",
-    "state": "TN",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/TN_2021.pdf"
-  },
-  {
-    "name": "Alex Padilla",
-    "affil": "Democrat",
-    "state": "CA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/CA_2021.pdf"
-  },
-  {
-    "name": "Jon Ossoff",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA_2021.pdf"
-  },
-  {
-    "name": "Raphael G. Warnock",
-    "affil": "Democrat",
-    "state": "GA",
-    "district": "",
-    "url": "https://environmentalenforcementwatch.org/report_cards/GA_2021.pdf"
-  }
+    {
+        "name":"Sherrod Brown",
+        "affil":"Democrat",
+        "state":"OH",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH_2023.pdf"
+    },
+    {
+        "name":"Maria Cantwell",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA_2023.pdf"
+    },
+    {
+        "name":"Benjamin L. Cardin",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD_2023.pdf"
+    },
+    {
+        "name":"Thomas R. Carper",
+        "affil":"Democrat",
+        "state":"DE",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/DE_2023.pdf"
+    },
+    {
+        "name":"Robert P. Casey, Jr.",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA_2023.pdf"
+    },
+    {
+        "name":"Dianne Feinstein",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA_2023.pdf"
+    },
+    {
+        "name":"Amy Klobuchar",
+        "affil":"Democrat",
+        "state":"MN",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN_2023.pdf"
+    },
+    {
+        "name":"Robert Menendez",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ_2023.pdf"
+    },
+    {
+        "name":"Bernard Sanders",
+        "affil":"Independent",
+        "state":"VT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VT_2023.pdf"
+    },
+    {
+        "name":"Debbie Stabenow",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI_2023.pdf"
+    },
+    {
+        "name":"Jon Tester",
+        "affil":"Democrat",
+        "state":"MT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MT_2023.pdf"
+    },
+    {
+        "name":"Sheldon Whitehouse",
+        "affil":"Democrat",
+        "state":"RI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/RI_2023.pdf"
+    },
+    {
+        "name":"John Barrasso",
+        "affil":"Republican",
+        "state":"WY",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WY_2023.pdf"
+    },
+    {
+        "name":"Roger F. Wicker",
+        "affil":"Republican",
+        "state":"MS",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MS_2023.pdf"
+    },
+    {
+        "name":"Susan M. Collins",
+        "affil":"Republican",
+        "state":"ME",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ME_2023.pdf"
+    },
+    {
+        "name":"John Cornyn",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX_2023.pdf"
+    },
+    {
+        "name":"Richard J. Durbin",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL_2023.pdf"
+    },
+    {
+        "name":"Lindsey Graham",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC_2023.pdf"
+    },
+    {
+        "name":"Mitch McConnell",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY_2023.pdf"
+    },
+    {
+        "name":"Jeff Merkley",
+        "affil":"Democrat",
+        "state":"OR",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR_2023.pdf"
+    },
+    {
+        "name":"Jack Reed",
+        "affil":"Democrat",
+        "state":"RI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/RI_2023.pdf"
+    },
+    {
+        "name":"James E. Risch",
+        "affil":"Republican",
+        "state":"ID",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ID_2023.pdf"
+    },
+    {
+        "name":"Jeanne Shaheen",
+        "affil":"Democrat",
+        "state":"NH",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NH_2023.pdf"
+    },
+    {
+        "name":"Mark R. Warner",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA_2023.pdf"
+    },
+    {
+        "name":"Kirsten E. Gillibrand",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY_2023.pdf"
+    },
+    {
+        "name":"Christopher A. Coons",
+        "affil":"Democrat",
+        "state":"DE",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/DE_2023.pdf"
+    },
+    {
+        "name":"Joe Manchin, III",
+        "affil":"Democrat",
+        "state":"WV",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WV_2023.pdf"
+    },
+    {
+        "name":"Tammy Baldwin",
+        "affil":"Democrat",
+        "state":"WI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI_2023.pdf"
+    },
+    {
+        "name":"Michael F. Bennet",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO_2023.pdf"
+    },
+    {
+        "name":"Marsha Blackburn",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN_2023.pdf"
+    },
+    {
+        "name":"Richard Blumenthal",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT_2023.pdf"
+    },
+    {
+        "name":"John Boozman",
+        "affil":"Republican",
+        "state":"AR",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AR_2023.pdf"
+    },
+    {
+        "name":"Shelley Moore Capito",
+        "affil":"Republican",
+        "state":"WV",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WV_2023.pdf"
+    },
+    {
+        "name":"Bill Cassidy",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA_2023.pdf"
+    },
+    {
+        "name":"Mike Crapo",
+        "affil":"Republican",
+        "state":"ID",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ID_2023.pdf"
+    },
+    {
+        "name":"Chuck Grassley",
+        "affil":"Republican",
+        "state":"IA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IA_2023.pdf"
+    },
+    {
+        "name":"Martin Heinrich",
+        "affil":"Democrat",
+        "state":"NM",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NM_2023.pdf"
+    },
+    {
+        "name":"Mazie K. Hirono",
+        "affil":"Democrat",
+        "state":"HI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/HI_2023.pdf"
+    },
+    {
+        "name":"John Hoeven",
+        "affil":"Republican",
+        "state":"ND",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ND_2023.pdf"
+    },
+    {
+        "name":"Ron Johnson",
+        "affil":"Republican",
+        "state":"WI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WI_2023.pdf"
+    },
+    {
+        "name":"James Lankford",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK_2023.pdf"
+    },
+    {
+        "name":"Mike Lee",
+        "affil":"Republican",
+        "state":"UT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/UT_2023.pdf"
+    },
+    {
+        "name":"Ben Ray Luj\u00e1n",
+        "affil":"Democrat",
+        "state":"NM",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NM_2023.pdf"
+    },
+    {
+        "name":"Edward J. Markey",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA_2023.pdf"
+    },
+    {
+        "name":"Jerry Moran",
+        "affil":"Republican",
+        "state":"KS",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KS_2023.pdf"
+    },
+    {
+        "name":"Lisa Murkowski",
+        "affil":"Republican",
+        "state":"AK",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AK_2023.pdf"
+    },
+    {
+        "name":"Christopher Murphy",
+        "affil":"Democrat",
+        "state":"CT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CT_2023.pdf"
+    },
+    {
+        "name":"Patty Murray",
+        "affil":"Democrat",
+        "state":"WA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WA_2023.pdf"
+    },
+    {
+        "name":"Rand Paul",
+        "affil":"Republican",
+        "state":"KY",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KY_2023.pdf"
+    },
+    {
+        "name":"Gary C. Peters",
+        "affil":"Democrat",
+        "state":"MI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MI_2023.pdf"
+    },
+    {
+        "name":"Marco Rubio",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL_2023.pdf"
+    },
+    {
+        "name":"Charles E. Schumer",
+        "affil":"Democrat",
+        "state":"NY",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NY_2023.pdf"
+    },
+    {
+        "name":"Tim Scott",
+        "affil":"Republican",
+        "state":"SC",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SC_2023.pdf"
+    },
+    {
+        "name":"John Thune",
+        "affil":"Republican",
+        "state":"SD",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SD_2023.pdf"
+    },
+    {
+        "name":"Chris Van Hollen",
+        "affil":"Democrat",
+        "state":"MD",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MD_2023.pdf"
+    },
+    {
+        "name":"Peter Welch",
+        "affil":"Democrat",
+        "state":"VT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VT_2023.pdf"
+    },
+    {
+        "name":"Ron Wyden",
+        "affil":"Democrat",
+        "state":"OR",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OR_2023.pdf"
+    },
+    {
+        "name":"Todd Young",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN_2023.pdf"
+    },
+    {
+        "name":"Brian Schatz",
+        "affil":"Democrat",
+        "state":"HI",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/HI_2023.pdf"
+    },
+    {
+        "name":"Tom Cotton",
+        "affil":"Republican",
+        "state":"AR",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AR_2023.pdf"
+    },
+    {
+        "name":"Kyrsten Sinema",
+        "affil":"Independent",
+        "state":"AZ",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ_2023.pdf"
+    },
+    {
+        "name":"Tammy Duckworth",
+        "affil":"Democrat",
+        "state":"IL",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IL_2023.pdf"
+    },
+    {
+        "name":"Elizabeth Warren",
+        "affil":"Democrat",
+        "state":"MA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MA_2023.pdf"
+    },
+    {
+        "name":"Angus S. King, Jr.",
+        "affil":"Independent",
+        "state":"ME",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ME_2023.pdf"
+    },
+    {
+        "name":"Steve Daines",
+        "affil":"Republican",
+        "state":"MT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MT_2023.pdf"
+    },
+    {
+        "name":"Kevin Cramer",
+        "affil":"Republican",
+        "state":"ND",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/ND_2023.pdf"
+    },
+    {
+        "name":"Deb Fischer",
+        "affil":"Republican",
+        "state":"NE",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NE_2023.pdf"
+    },
+    {
+        "name":"Markwayne Mullin",
+        "affil":"Republican",
+        "state":"OK",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OK_2023.pdf"
+    },
+    {
+        "name":"Ted Cruz",
+        "affil":"Republican",
+        "state":"TX",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TX_2023.pdf"
+    },
+    {
+        "name":"Tim Kaine",
+        "affil":"Democrat",
+        "state":"VA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/VA_2023.pdf"
+    },
+    {
+        "name":"Cory A. Booker",
+        "affil":"Democrat",
+        "state":"NJ",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NJ_2023.pdf"
+    },
+    {
+        "name":"Dan Sullivan",
+        "affil":"Republican",
+        "state":"AK",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AK_2023.pdf"
+    },
+    {
+        "name":"Joni Ernst",
+        "affil":"Republican",
+        "state":"IA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IA_2023.pdf"
+    },
+    {
+        "name":"Thom Tillis",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC_2023.pdf"
+    },
+    {
+        "name":"Mike Rounds",
+        "affil":"Republican",
+        "state":"SD",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/SD_2023.pdf"
+    },
+    {
+        "name":"John Kennedy",
+        "affil":"Republican",
+        "state":"LA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/LA_2023.pdf"
+    },
+    {
+        "name":"Margaret Wood Hassan",
+        "affil":"Democrat",
+        "state":"NH",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NH_2023.pdf"
+    },
+    {
+        "name":"Catherine Cortez Masto",
+        "affil":"Democrat",
+        "state":"NV",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NV_2023.pdf"
+    },
+    {
+        "name":"Roger Marshall",
+        "affil":"Republican",
+        "state":"KS",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/KS_2023.pdf"
+    },
+    {
+        "name":"Ted Budd",
+        "affil":"Republican",
+        "state":"NC",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NC_2023.pdf"
+    },
+    {
+        "name":"Jacky Rosen",
+        "affil":"Democrat",
+        "state":"NV",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NV_2023.pdf"
+    },
+    {
+        "name":"Tina Smith",
+        "affil":"Democrat",
+        "state":"MN",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MN_2023.pdf"
+    },
+    {
+        "name":"Cindy Hyde-Smith",
+        "affil":"Republican",
+        "state":"MS",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MS_2023.pdf"
+    },
+    {
+        "name":"Rick Scott",
+        "affil":"Republican",
+        "state":"FL",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/FL_2023.pdf"
+    },
+    {
+        "name":"Mike Braun",
+        "affil":"Republican",
+        "state":"IN",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/IN_2023.pdf"
+    },
+    {
+        "name":"Josh Hawley",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO_2023.pdf"
+    },
+    {
+        "name":"Mitt Romney",
+        "affil":"Republican",
+        "state":"UT",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/UT_2023.pdf"
+    },
+    {
+        "name":"Mark Kelly",
+        "affil":"Democrat",
+        "state":"AZ",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AZ_2023.pdf"
+    },
+    {
+        "name":"Cynthia M. Lummis",
+        "affil":"Republican",
+        "state":"WY",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/WY_2023.pdf"
+    },
+    {
+        "name":"Tommy Tuberville",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL_2023.pdf"
+    },
+    {
+        "name":"John W. Hickenlooper",
+        "affil":"Democrat",
+        "state":"CO",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CO_2023.pdf"
+    },
+    {
+        "name":"Bill Hagerty",
+        "affil":"Republican",
+        "state":"TN",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/TN_2023.pdf"
+    },
+    {
+        "name":"Alex Padilla",
+        "affil":"Democrat",
+        "state":"CA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/CA_2023.pdf"
+    },
+    {
+        "name":"Jon Ossoff",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA_2023.pdf"
+    },
+    {
+        "name":"Raphael G. Warnock",
+        "affil":"Democrat",
+        "state":"GA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/GA_2023.pdf"
+    },
+    {
+        "name":"Katie Boyd Britt",
+        "affil":"Republican",
+        "state":"AL",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/AL_2023.pdf"
+    },
+    {
+        "name":"Eric Schmitt",
+        "affil":"Republican",
+        "state":"MO",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/MO_2023.pdf"
+    },
+    {
+        "name":"J.D. Vance",
+        "affil":"Republican",
+        "state":"OH",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/OH_2023.pdf"
+    },
+    {
+        "name":"John Fetterman",
+        "affil":"Democrat",
+        "state":"PA",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/PA_2023.pdf"
+    },
+    {
+        "name":"Pete Ricketts",
+        "affil":"Republican",
+        "state":"NE",
+        "district":"",
+        "url":"https:\/\/environmentalenforcementwatch.org\/report_cards\/NE_2023.pdf"
+    }
 ]

--- a/src/helpers/senate.js
+++ b/src/helpers/senate.js
@@ -1,4 +1,4 @@
-[
+export const Senate = [
     {
         "name":"Sherrod Brown",
         "affil":"Democrat",


### PR DESCRIPTION
This branch updates src/helpers/house.js and senate.js with the current congress. URL links are to the 2023 congressional report cards.